### PR TITLE
OpenKit objects shall extend IDisposable

### DIFF
--- a/src/openkit-shared/API/IAction.cs
+++ b/src/openkit-shared/API/IAction.cs
@@ -14,13 +14,15 @@
 // limitations under the License.
 //
 
+using System;
+
 namespace Dynatrace.OpenKit.API
 {
 
     /// <summary>
     ///  This interface provides functionality to report events/values/errors and traces web requests.
     /// </summary>
-    public interface IAction
+    public interface IAction : IDisposable
     {
 
         /// <summary>

--- a/src/openkit-shared/API/IOpenKit.cs
+++ b/src/openkit-shared/API/IOpenKit.cs
@@ -14,13 +14,15 @@
 // limitations under the License.
 //
 
+using System;
+
 namespace Dynatrace.OpenKit.API
 {
 
     /// <summary>
     ///  This interface provides basic OpenKit functionality, like creating a Session and shutting down OpenKit.
     /// </summary>
-    public interface IOpenKit
+    public interface IOpenKit : IDisposable
     {   
         /// <summary>
         ///  Waits until OpenKit is fully initialized.

--- a/src/openkit-shared/API/ISession.cs
+++ b/src/openkit-shared/API/ISession.cs
@@ -14,13 +14,15 @@
 // limitations under the License.
 //
 
+using System;
+
 namespace Dynatrace.OpenKit.API
 {
 
     /// <summary>
     ///  This interface provides functionality to create Actions in a Session.
     /// </summary>
-    public interface ISession
+    public interface ISession : IDisposable
     {
 
         /// <summary>

--- a/src/openkit-shared/API/IWebRequestTracer.cs
+++ b/src/openkit-shared/API/IWebRequestTracer.cs
@@ -14,13 +14,15 @@
 // limitations under the License.
 //
 
+using System;
+
 namespace Dynatrace.OpenKit.API
 {
 
     /// <summary>
     ///  This interface allows tracing and timing of a web request.
     /// </summary>
-    public interface IWebRequestTracer
+    public interface IWebRequestTracer : IDisposable
     {
 
         /// <summary>
@@ -60,10 +62,6 @@ namespace Dynatrace.OpenKit.API
         /// <param name="bytesReceived">number of bytes received by the web request</param>
         /// <returns></returns>
         IWebRequestTracer SetBytesReceived(int bytesReceived);
-
-
-
-
     }
 
 }

--- a/src/openkit-shared/Core/Action.cs
+++ b/src/openkit-shared/Core/Action.cs
@@ -159,5 +159,10 @@ namespace Dynatrace.OpenKit.Core
 
             return parentAction; // can be null if there's no parent Action!
         }
+
+        public void Dispose()
+        {
+            LeaveAction();
+        }
     }
 }

--- a/src/openkit-shared/Core/NullAction.cs
+++ b/src/openkit-shared/Core/NullAction.cs
@@ -37,6 +37,11 @@ namespace Dynatrace.OpenKit.Core
             this.parentAction = parentAction;
         }
 
+        public void Dispose()
+        {
+            LeaveAction();
+        }
+
         public IAction LeaveAction()
         {
             return parentAction;

--- a/src/openkit-shared/Core/NullSession.cs
+++ b/src/openkit-shared/Core/NullSession.cs
@@ -22,6 +22,11 @@ namespace Dynatrace.OpenKit.Core
     {
         private static readonly IRootAction NullRootAction = new NullRootAction();
 
+        public void Dispose()
+        {
+            End();
+        }
+
         public void End()
         {
             // intentionally left empty, due to NullObject pattern

--- a/src/openkit-shared/Core/NullWebRequestTracer.cs
+++ b/src/openkit-shared/Core/NullWebRequestTracer.cs
@@ -50,5 +50,10 @@ namespace Dynatrace.OpenKit.Core
         {
             // intentionally left empty, due to NullObject pattern
         }
+
+        public void Dispose()
+        {
+            Stop();
+        }
     }
 }

--- a/src/openkit-shared/Core/OpenKit.cs
+++ b/src/openkit-shared/Core/OpenKit.cs
@@ -83,6 +83,11 @@ namespace Dynatrace.OpenKit.Core
 
         // *** IOpenKit interface methods ***
 
+        public void Dispose()
+        {
+            Shutdown();
+        }
+
         public bool WaitForInitCompletion()
         {
             return beaconSender.WaitForInitCompletion();

--- a/src/openkit-shared/Core/Session.cs
+++ b/src/openkit-shared/Core/Session.cs
@@ -38,7 +38,7 @@ namespace Dynatrace.OpenKit.Core
 
         // used for taking care to really leave all Actions at the end of this Session
         private SynchronizedQueue<IAction> openRootActions = new SynchronizedQueue<IAction>();
-       
+
 
         public Session(BeaconSender beaconSender, Beacon beacon)
         {
@@ -60,6 +60,11 @@ namespace Dynatrace.OpenKit.Core
         internal bool IsSessionEnded => EndTime != -1;
 
         // *** ISession interface methods ***
+
+        public void Dispose()
+        {
+            End();
+        }
 
         public IRootAction EnterAction(string actionName)
         {

--- a/src/openkit-shared/Core/WebRequestTracerBase.cs
+++ b/src/openkit-shared/Core/WebRequestTracerBase.cs
@@ -81,6 +81,11 @@ namespace Dynatrace.OpenKit.Core
 
         internal bool IsStopped => EndTime != -1;
 
+        public void Dispose()
+        {
+            Stop();
+        }
+
         public IWebRequestTracer Start()
         {
             if (!IsStopped)

--- a/tests/openkit-shared-tests/Core/SessionTest.cs
+++ b/tests/openkit-shared-tests/Core/SessionTest.cs
@@ -20,6 +20,7 @@ using Dynatrace.OpenKit.Protocol;
 using Dynatrace.OpenKit.Providers;
 using NSubstitute;
 using NUnit.Framework;
+using System;
 
 namespace Dynatrace.OpenKit.Core
 {
@@ -208,6 +209,26 @@ namespace Dynatrace.OpenKit.Core
 
             // then
             beaconSendingContext.Received(1).FinishSession(target);
+        }
+
+        [Test]
+        public void DisposingASessionEndsTheSession()
+        {
+            // given
+            int timestamp = 100;
+            mockTimingProvider.ProvideTimestampInMilliseconds().Returns(x =>
+            {
+                timestamp++;
+                return timestamp;
+            });
+
+            IDisposable target = new Session(beaconSender, beacon);
+
+            // when
+            target.Dispose();
+
+            // then
+            beaconSendingContext.Received(1).FinishSession((Session)target);
         }
 
         [Test]

--- a/tests/openkit-shared-tests/Core/WebRequestTracerBaseTest.cs
+++ b/tests/openkit-shared-tests/Core/WebRequestTracerBaseTest.cs
@@ -21,6 +21,7 @@ using Dynatrace.OpenKit.Protocol;
 using Dynatrace.OpenKit.Providers;
 using NSubstitute;
 using NUnit.Framework;
+using System;
 
 namespace Dynatrace.OpenKit.Core
 {
@@ -94,6 +95,19 @@ namespace Dynatrace.OpenKit.Core
 
             // then
             Assert.That(target.IsStopped, Is.True);
+        }
+        
+        [Test]
+        public void DisposingAWebRequestTracerStopsIt()
+        {
+            // given
+            IDisposable target = new TestWebRequestTracerBase(beacon, action);
+
+            // when disposing the target
+            target.Dispose();
+
+            // then
+            Assert.That(((WebRequestTracerBase)target).IsStopped, Is.True);
         }
 
         [Test]


### PR DESCRIPTION
OpenKit objects are extending/implementing the IDisposable interface
to allow easier wrapping in using blocks.

Allthough the objects currently do not need to free any resources,
it's easier to wrap them in a using block to guarantee that
the object is left/ended on completion of the using block.