### PR TITLE
Check null/empty strings

### DIFF
--- a/src/openkit-shared/API/IAction.cs
+++ b/src/openkit-shared/API/IAction.cs
@@ -28,6 +28,10 @@ namespace Dynatrace.OpenKit.API
         /// <summary>
         ///  Reports an event with a specified name (but without any value).
         /// </summary>
+        /// <remarks>
+        /// If given <paramref name="eventName"/> is <code>null</code>
+        /// or an empty string, then no event is reported to the system.
+        /// </remarks>
         /// <param name="eventName">name of the event</param>
         /// <returns>this Action (for usage as fluent API)</returns>
         IAction ReportEvent(string eventName);
@@ -35,6 +39,10 @@ namespace Dynatrace.OpenKit.API
         /// <summary>
         ///  Reports an int value with a specified name.
         /// </summary>
+        /// <remarks>
+        /// If given <paramref name="valueName"/> is <code>null</code> or an empty string,
+        /// no value is reported.
+        /// </remarks>
         /// <param name="valueName">name of this value</param>
         /// <param name="value">value itself</param>
         /// <returns>this Action (for usage as fluent API)</returns>
@@ -43,6 +51,10 @@ namespace Dynatrace.OpenKit.API
         /// <summary>
         ///  Reports a double value with a specified name.
         /// </summary>
+        /// <remarks>
+        /// If given <paramref name="valueName"/> is <code>null</code> or an empty string,
+        /// no value is reported.
+        /// </remarks>
         /// <param name="valueName">name of this value</param>
         /// <param name="value">value itself</param>
         /// <returns>this Action (for usage as fluent API)</returns>
@@ -51,6 +63,10 @@ namespace Dynatrace.OpenKit.API
         /// <summary>
         ///  Reports a string value with a specified name.
         /// </summary>
+        /// <remarks>
+        /// If given <paramref name="valueName"/> is <code>null</code> or an empty string,
+        /// no value is reported.
+        /// </remarks>
         /// <param name="valueName">name of this value</param>
         /// <param name="value">value itself</param>
         /// <returns>this Action (for usage as fluent API)</returns>
@@ -59,6 +75,10 @@ namespace Dynatrace.OpenKit.API
         /// <summary>
         ///  Reports an error with a specified name, error code and reason.
         /// </summary>
+        /// <remarks>
+        /// If given <paramref name="errorName"/> is <code>null</code> or an empty string,
+        /// no error is reported.
+        /// </remarks>
         /// <param name="errorName">name of this error</param>
         /// <param name="errorCode">numeric error code of this error</param>
         /// <param name="reason">reason for this error</param>
@@ -72,6 +92,10 @@ namespace Dynatrace.OpenKit.API
         ///  If the web request is continued on a server-side Agent (e.g. Java, .NET, ...) this Session will be correlated to
         ///  the resulting server-side PurePath.
         /// </summary>
+        /// <remarks>
+        /// If given <paramref name="url"/> is <code>null</code> or an empty string, then
+        /// a <see cref="NullWebRequestTracer"/> is returned and nothing is reported to the server.
+        /// </remarks>
         /// <param name="url">the URL of the web request to be traced and timed</param>
         /// <returns>a WebRequestTracer which allows getting the tag value and adding timing information</returns>
         IWebRequestTracer TraceWebRequest(string url);
@@ -81,7 +105,6 @@ namespace Dynatrace.OpenKit.API
         /// </summary>
         /// <returns>the parent Action, or null if there is no parent Action</returns>
         IAction LeaveAction();
-
     }
 
 }

--- a/src/openkit-shared/API/IRootAction.cs
+++ b/src/openkit-shared/API/IRootAction.cs
@@ -24,6 +24,10 @@ namespace Dynatrace.OpenKit.API
         /// <summary>
         ///  Enters a child Action with a specified name on this Action.
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="actionName"/> is <code>null</code> or an empty string,
+        /// a <see cref="NullAction"/> is entered and therefore no action tracing happens.
+        /// </remarks>
         /// <param name="actionName">name of the Action</param>
         /// <returns>Action instance to work with</returns>
         IAction EnterAction(string actionName);

--- a/src/openkit-shared/API/ISession.cs
+++ b/src/openkit-shared/API/ISession.cs
@@ -28,6 +28,10 @@ namespace Dynatrace.OpenKit.API
         /// <summary>
         ///  Enters an Action with a specified name in this Session.
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="actionName"/> is <code>null</code> or an empty string,
+        /// a <see cref="NullAction"/> is entered and therefore no action tracing happens.
+        /// </remarks>
         /// <param name="actionName">name of the Action</param>
         /// <returns>Action instance to work with</returns>
         IRootAction EnterAction(string actionName);
@@ -35,6 +39,10 @@ namespace Dynatrace.OpenKit.API
         /// <summary>
         ///  Tags a session with the provided <code>userTag</code>
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="userTag"/> is <code>null</code> or an empty string,
+        /// no user identification is sent to the server.
+        /// </remarks>
         /// <param name="userTag"></param>
         void IdentifyUser(string userTag);
 
@@ -50,7 +58,6 @@ namespace Dynatrace.OpenKit.API
         ///  Ends this Session and marks it as ready for immediate sending.
         /// </summary>
         void End();
-
     }
 
 }

--- a/src/openkit-shared/Core/Action.cs
+++ b/src/openkit-shared/Core/Action.cs
@@ -28,6 +28,8 @@ namespace Dynatrace.OpenKit.Core
     {
         private static readonly IWebRequestTracer NullWebRequestTracer = new NullWebRequestTracer();
 
+        private readonly ILogger logger;
+
         // Action ID, name and parent ID (default: null)
         private int id;
         private string name;
@@ -45,12 +47,13 @@ namespace Dynatrace.OpenKit.Core
         // data structures for managing IAction hierarchies
         private SynchronizedQueue<IAction> thisLevelActions = null;
 
-        public Action(Beacon beacon, string name, SynchronizedQueue<IAction> thisLevelActions) : this(beacon, name, null, thisLevelActions)
+        public Action(ILogger logger, Beacon beacon, string name, SynchronizedQueue<IAction> thisLevelActions) : this(logger, beacon, name, null, thisLevelActions)
         {
         }
 
-        internal Action(Beacon beacon, string name, Action parentAction, SynchronizedQueue<IAction> thisLevelActions)
+        internal Action(ILogger logger, Beacon beacon, string name, Action parentAction, SynchronizedQueue<IAction> thisLevelActions)
         {
+            this.logger = logger;
             this.beacon = beacon;
             this.parentAction = parentAction;
 
@@ -62,6 +65,8 @@ namespace Dynatrace.OpenKit.Core
             this.thisLevelActions = thisLevelActions;
             this.thisLevelActions.Put(this);
         }
+
+        public ILogger Logger => logger;
 
         public int ID => id;
 
@@ -81,6 +86,11 @@ namespace Dynatrace.OpenKit.Core
 
         public IAction ReportEvent(string eventName)
         {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                logger.Warn("Action.reportEvent: eventName must not be null or empty");
+                return this;
+            }
             if (!IsActionLeft)
             {
                 beacon.ReportEvent(this, eventName);
@@ -90,6 +100,11 @@ namespace Dynatrace.OpenKit.Core
 
         public IAction ReportValue(string valueName, string value)
         {
+            if (string.IsNullOrEmpty(valueName))
+            {
+                logger.Warn("Action.reportValue (string): valueName must not be null or empty");
+                return this;
+            }
             if (!IsActionLeft)
             {
                 beacon.ReportValue(this, valueName, value);
@@ -99,6 +114,11 @@ namespace Dynatrace.OpenKit.Core
 
         public IAction ReportValue(string valueName, double value)
         {
+            if (string.IsNullOrEmpty(valueName))
+            {
+                logger.Warn("Action.reportValue (double): valueName must not be null or empty");
+                return this;
+            }
             if (!IsActionLeft)
             {
                 beacon.ReportValue(this, valueName, value);
@@ -108,6 +128,11 @@ namespace Dynatrace.OpenKit.Core
 
         public IAction ReportValue(string valueName, int value)
         {
+            if (string.IsNullOrEmpty(valueName))
+            {
+                logger.Warn("Action.reportValue (int): valueName must not be null or empty");
+                return this;
+            }
             if (!IsActionLeft)
             {
                 beacon.ReportValue(this, valueName, value);
@@ -117,6 +142,11 @@ namespace Dynatrace.OpenKit.Core
 
         public IAction ReportError(string errorName, int errorCode, string reason)
         {
+            if (string.IsNullOrEmpty(errorName))
+            {
+                logger.Warn("Action.reportError: errorName must not be null or empty");
+                return this;
+            }
             if (!IsActionLeft)
             {
                 beacon.ReportError(this, errorName, errorCode, reason);
@@ -126,6 +156,11 @@ namespace Dynatrace.OpenKit.Core
 
         public IWebRequestTracer TraceWebRequest(string url)
         {
+            if (string.IsNullOrEmpty(url))
+            {
+                logger.Warn("Action.traceWebRequest (String): url must not be null or empty");
+                return NullWebRequestTracer;
+            }
             if (!IsActionLeft)
             {
                 return new WebRequestTracerStringURL(beacon, this, url);

--- a/src/openkit-shared/Core/Action.cs
+++ b/src/openkit-shared/Core/Action.cs
@@ -66,8 +66,6 @@ namespace Dynatrace.OpenKit.Core
             this.thisLevelActions.Put(this);
         }
 
-        public ILogger Logger => logger;
-
         public int ID => id;
 
         public string Name => name;
@@ -84,11 +82,13 @@ namespace Dynatrace.OpenKit.Core
 
         internal bool IsActionLeft => EndTime != -1L;
 
+        internal ILogger Logger => logger;
+
         public IAction ReportEvent(string eventName)
         {
             if (string.IsNullOrEmpty(eventName))
             {
-                logger.Warn("Action.reportEvent: eventName must not be null or empty");
+                logger.Warn("Action.ReportEvent: eventName must not be null or empty");
                 return this;
             }
             if (!IsActionLeft)
@@ -102,7 +102,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(valueName))
             {
-                logger.Warn("Action.reportValue (string): valueName must not be null or empty");
+                logger.Warn("Action.ReportValue (string): valueName must not be null or empty");
                 return this;
             }
             if (!IsActionLeft)
@@ -116,7 +116,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(valueName))
             {
-                logger.Warn("Action.reportValue (double): valueName must not be null or empty");
+                logger.Warn("Action.ReportValue (double): valueName must not be null or empty");
                 return this;
             }
             if (!IsActionLeft)
@@ -130,7 +130,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(valueName))
             {
-                logger.Warn("Action.reportValue (int): valueName must not be null or empty");
+                logger.Warn("Action.ReportValue (int): valueName must not be null or empty");
                 return this;
             }
             if (!IsActionLeft)
@@ -144,7 +144,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(errorName))
             {
-                logger.Warn("Action.reportError: errorName must not be null or empty");
+                logger.Warn("Action.ReportError: errorName must not be null or empty");
                 return this;
             }
             if (!IsActionLeft)
@@ -158,7 +158,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(url))
             {
-                logger.Warn("Action.traceWebRequest (String): url must not be null or empty");
+                logger.Warn("Action.TraceWebRequest (String): url must not be null or empty");
                 return NullWebRequestTracer;
             }
             if (!IsActionLeft)

--- a/src/openkit-shared/Core/OpenKit.cs
+++ b/src/openkit-shared/Core/OpenKit.cs
@@ -117,7 +117,7 @@ namespace Dynatrace.OpenKit.Core
             // create beacon for session
             var beacon = new Beacon(logger, beaconCache, configuration, clientIPAddress, threadIDProvider, timingProvider);
             // create session
-            return new Session(beaconSender, beacon);
+            return new Session(logger, beaconSender, beacon);
         }
 
         public void Shutdown()

--- a/src/openkit-shared/Core/RootAction.cs
+++ b/src/openkit-shared/Core/RootAction.cs
@@ -43,7 +43,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(actionName))
             {
-                    Logger.Warn("RootAction.enterAction: actionName must not be null or empty");
+                    Logger.Warn("RootAction.EnterAction: actionName must not be null or empty");
                     return new NullAction(this);
             }
             if (!IsActionLeft)

--- a/src/openkit-shared/Core/RootAction.cs
+++ b/src/openkit-shared/Core/RootAction.cs
@@ -31,8 +31,8 @@ namespace Dynatrace.OpenKit.Core
 
         // *** constructors ***
 
-        public RootAction(Beacon beacon, string name, SynchronizedQueue<IAction> thisLevelActions)
-            : base(beacon, name, thisLevelActions)
+        public RootAction(ILogger logger, Beacon beacon, string name, SynchronizedQueue<IAction> thisLevelActions)
+            : base(logger, beacon, name, thisLevelActions)
         {
             this.beacon = beacon;
         }
@@ -41,9 +41,14 @@ namespace Dynatrace.OpenKit.Core
 
         public IAction EnterAction(string actionName)
         {
+            if (string.IsNullOrEmpty(actionName))
+            {
+                    Logger.Warn("RootAction.enterAction: actionName must not be null or empty");
+                    return new NullAction(this);
+            }
             if (!IsActionLeft)
             {
-                return new Action(beacon, actionName, this, openChildActions);
+                return new Action(Logger, beacon, actionName, this, openChildActions);
             }
             return new NullAction(this);
         }

--- a/src/openkit-shared/Core/Session.cs
+++ b/src/openkit-shared/Core/Session.cs
@@ -73,7 +73,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(actionName))
             {
-                logger.Warn("Session.enterAction: actionName must not be null or empty");
+                logger.Warn("Session.EnterAction: actionName must not be null or empty");
                 return NullRootAction;
             }
             if (!IsSessionEnded)
@@ -88,7 +88,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(userTag))
             {
-                logger.Warn("Session.identifyUser: userTag must not be null or empty");
+                logger.Warn("Session.IdentifyUser: userTag must not be null or empty");
                 return;
             }
             if (!IsSessionEnded)
@@ -101,7 +101,7 @@ namespace Dynatrace.OpenKit.Core
         {
             if (string.IsNullOrEmpty(errorName))
             {
-                logger.Warn("Session.reportCrash: errorName must not be null or empty");
+                logger.Warn("Session.ReportCrash: errorName must not be null or empty");
                 return;
             }
             if (!IsSessionEnded)

--- a/src/openkit-shared/Core/Session.cs
+++ b/src/openkit-shared/Core/Session.cs
@@ -29,6 +29,8 @@ namespace Dynatrace.OpenKit.Core
     {
         private static readonly NullRootAction NullRootAction = new NullRootAction();
 
+        private readonly ILogger logger;
+
         // end time of this Session
         private long endTime = -1;
 
@@ -40,8 +42,9 @@ namespace Dynatrace.OpenKit.Core
         private SynchronizedQueue<IAction> openRootActions = new SynchronizedQueue<IAction>();
 
 
-        public Session(BeaconSender beaconSender, Beacon beacon)
+        public Session(ILogger logger, BeaconSender beaconSender, Beacon beacon)
         {
+            this.logger = logger;
             this.beaconSender = beaconSender;
             this.beacon = beacon;
 
@@ -68,9 +71,14 @@ namespace Dynatrace.OpenKit.Core
 
         public IRootAction EnterAction(string actionName)
         {
+            if (string.IsNullOrEmpty(actionName))
+            {
+                logger.Warn("Session.enterAction: actionName must not be null or empty");
+                return NullRootAction;
+            }
             if (!IsSessionEnded)
             {
-                return new RootAction(beacon, actionName, openRootActions);
+                return new RootAction(logger, beacon, actionName, openRootActions);
             }
 
             return NullRootAction;
@@ -78,6 +86,11 @@ namespace Dynatrace.OpenKit.Core
 
         public void IdentifyUser(string userTag)
         {
+            if (string.IsNullOrEmpty(userTag))
+            {
+                logger.Warn("Session.identifyUser: userTag must not be null or empty");
+                return;
+            }
             if (!IsSessionEnded)
             {
                 beacon.IdentifyUser(userTag);
@@ -86,6 +99,11 @@ namespace Dynatrace.OpenKit.Core
 
         public void ReportCrash(string errorName, string reason, string stacktrace)
         {
+            if (string.IsNullOrEmpty(errorName))
+            {
+                logger.Warn("Session.reportCrash: errorName must not be null or empty");
+                return;
+            }
             if (!IsSessionEnded)
             {
                 beacon.ReportCrash(errorName, reason, stacktrace);

--- a/src/openkit-shared/Protocol/Beacon.cs
+++ b/src/openkit-shared/Protocol/Beacon.cs
@@ -165,35 +165,17 @@ namespace Dynatrace.OpenKit.Protocol
         /// <summary>
         /// create next ID
         /// </summary>
-        public int NextID
-        {
-            get
-            {
-                return Interlocked.Increment(ref nextID);
-            }
-        }
+        public int NextID => Interlocked.Increment(ref nextID);
 
         /// <summary>
         /// create next sequence number
         /// </summary>
-        public int NextSequenceNumber
-        {
-            get
-            {
-                return Interlocked.Increment(ref nextSequenceNumber);
-            }
-        }
+        public int NextSequenceNumber => Interlocked.Increment(ref nextSequenceNumber);
 
         /// <summary>
         /// Get the current timestamp in milliseconds by delegating to TimingProvider
         /// </summary>
-        public long CurrentTimestamp
-        {
-            get
-            {
-                return timingProvider.ProvideTimestampInMilliseconds();
-            }
-        }
+        public long CurrentTimestamp => timingProvider.ProvideTimestampInMilliseconds();
 
         /// <summary>
         /// Returns an immutable list of the event data
@@ -335,7 +317,10 @@ namespace Dynatrace.OpenKit.Protocol
             StringBuilder eventBuilder = new StringBuilder();
 
             var eventTimestamp = BuildEvent(eventBuilder, EventType.VALUE_STRING, valueName, parentAction);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_VALUE, Truncate(value));
+            if (value != null)
+            {
+                AddKeyValuePair(eventBuilder, BEACON_KEY_VALUE, Truncate(value));
+            }
 
             AddEventData(eventTimestamp, eventBuilder);
         }
@@ -378,7 +363,10 @@ namespace Dynatrace.OpenKit.Protocol
             AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
             AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(timestamp));
             AddKeyValuePair(eventBuilder, BEACON_KEY_ERROR_CODE, errorCode);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
+            if (reason != null)
+            {
+                AddKeyValuePair(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
+            }
 
             AddEventData(timestamp, eventBuilder);
         }
@@ -405,8 +393,14 @@ namespace Dynatrace.OpenKit.Protocol
             AddKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, 0);                                  // no parent action
             AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
             AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(timestamp));
-            AddKeyValuePair(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_ERROR_STACKTRACE, stacktrace);
+            if (reason != null)
+            {
+                AddKeyValuePair(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
+            }
+            if (stacktrace != null)
+            {
+                AddKeyValuePair(eventBuilder, BEACON_KEY_ERROR_STACKTRACE, stacktrace);
+            }
 
             AddEventData(timestamp, eventBuilder);
         }
@@ -709,6 +703,6 @@ namespace Dynatrace.OpenKit.Protocol
             return timestamp - sessionStartTime;
         }
 
-        public bool IsEmpty { get { return beaconCache.IsEmpty(sessionNumber); } }
+        public bool IsEmpty=> beaconCache.IsEmpty(sessionNumber);
     }
 }

--- a/tests/openkit-shared-tests/Core/ActionTest.cs
+++ b/tests/openkit-shared-tests/Core/ActionTest.cs
@@ -216,7 +216,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportEvent: eventName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportEvent: eventName must not be null or empty");
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportEvent: eventName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportEvent: eventName must not be null or empty");
         }
 
         [Test]
@@ -286,7 +286,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportValue (int): valueName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportValue (int): valueName must not be null or empty");
         }
 
         [Test]
@@ -305,7 +305,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportValue (int): valueName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportValue (int): valueName must not be null or empty");
         }
 
         [Test]
@@ -357,7 +357,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportValue (double): valueName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportValue (double): valueName must not be null or empty");
         }
 
         [Test]
@@ -376,7 +376,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportValue (double): valueName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportValue (double): valueName must not be null or empty");
         }
 
         [Test]
@@ -428,7 +428,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportValue (string): valueName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportValue (string): valueName must not be null or empty");
         }
 
         [Test]
@@ -447,7 +447,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportValue (string): valueName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportValue (string): valueName must not be null or empty");
         }
 
         [Test]
@@ -511,7 +511,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportError: errorName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportError: errorName must not be null or empty");
         }
 
         [Test]
@@ -529,7 +529,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.SameAs(target));
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.reportError: errorName must not be null or empty");
+            logger.Received(1).Warn("Action.ReportError: errorName must not be null or empty");
         }
 
         [Test]
@@ -592,7 +592,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.Not.Null.And.InstanceOf<NullWebRequestTracer>());
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.traceWebRequest (String): url must not be null or empty");
+            logger.Received(1).Warn("Action.TraceWebRequest (String): url must not be null or empty");
         }
 
         [Test]
@@ -610,7 +610,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.Not.Null.And.InstanceOf<NullWebRequestTracer>());
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Action.traceWebRequest (String): url must not be null or empty");
+            logger.Received(1).Warn("Action.TraceWebRequest (String): url must not be null or empty");
         }
 
         [Test]

--- a/tests/openkit-shared-tests/Core/ActionTest.cs
+++ b/tests/openkit-shared-tests/Core/ActionTest.cs
@@ -31,13 +31,15 @@ namespace Dynatrace.OpenKit.Core
         private Beacon beacon;
         private OpenKitConfiguration testConfiguration;
         private ITimingProvider mockTimingProvider;
+        private ILogger logger;
         
         [SetUp]
         public void SetUp()
         {
             mockTimingProvider = Substitute.For<ITimingProvider>();
             testConfiguration = new TestConfiguration();
-            beacon = new Beacon(Substitute.For<ILogger>(),
+            logger = Substitute.For<ILogger>();
+            beacon = new Beacon(logger,
                                 new BeaconCache(),
                                 testConfiguration,
                                 "127.0.0.1",
@@ -50,7 +52,7 @@ namespace Dynatrace.OpenKit.Core
         {
             // given
             while (beacon.NextID < 10) ; // increment the id
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.ID, Is.EqualTo(11));
@@ -60,7 +62,7 @@ namespace Dynatrace.OpenKit.Core
         public void NameIsSet()
         {
             // given
-            var target = new Action(beacon, "test name", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test name", new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.Name, Is.EqualTo("test name"));
@@ -70,7 +72,7 @@ namespace Dynatrace.OpenKit.Core
         public void ParentIDIsZeroIfActionHasNoParent()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.ParentID, Is.EqualTo(0));
@@ -81,8 +83,8 @@ namespace Dynatrace.OpenKit.Core
         {
             // given
             while (beacon.NextID < 10) ; // increment the id
-            var parent = new Action(beacon, "parent", new SynchronizedQueue<IAction>());
-            var target = new Action(beacon, "test", parent, new SynchronizedQueue<IAction>());
+            var parent = new Action(logger, beacon, "parent", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", parent, new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.ParentID, Is.EqualTo(11));
@@ -93,7 +95,7 @@ namespace Dynatrace.OpenKit.Core
         {
             // given
             mockTimingProvider.ProvideTimestampInMilliseconds().Returns(1234L);
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.StartTime, Is.EqualTo(1234L));
@@ -103,7 +105,7 @@ namespace Dynatrace.OpenKit.Core
         public void EndTimeIsSetToMinusOneInConstructor()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.EndTime, Is.EqualTo(-1L));
@@ -114,7 +116,7 @@ namespace Dynatrace.OpenKit.Core
         {
             // given
             while (beacon.NextSequenceNumber < 5) ; // increment sequence number
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.StartSequenceNo, Is.EqualTo(6));
@@ -125,7 +127,7 @@ namespace Dynatrace.OpenKit.Core
         {
             // given
             while (beacon.NextSequenceNumber < 5) ; // increment sequence number
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.EndSequenceNo, Is.EqualTo(-1));
@@ -135,7 +137,7 @@ namespace Dynatrace.OpenKit.Core
         public void ANewlyCreatedActionIsNotLeft()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // then
             Assert.That(target.IsActionLeft, Is.False);
@@ -148,7 +150,7 @@ namespace Dynatrace.OpenKit.Core
             var actions = new SynchronizedQueue<IAction>();
 
             // when constructing the action
-            var target = new Action(beacon, "test", actions);
+            var target = new Action(logger, beacon, "test", actions);
 
             // then
             Assert.That(actions.IsEmpty, Is.False);
@@ -159,7 +161,7 @@ namespace Dynatrace.OpenKit.Core
         public void AfterLeavingAnActionItIsLeft()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // when
             target.LeaveAction();
@@ -172,7 +174,7 @@ namespace Dynatrace.OpenKit.Core
         public void ReportEvent()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             beacon.ClearData();
 
             // when reporting an event
@@ -187,7 +189,7 @@ namespace Dynatrace.OpenKit.Core
         public void ReportEventDoesNothingIfActionIsLeft()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             target.LeaveAction();
             beacon.ClearData();
 
@@ -200,10 +202,46 @@ namespace Dynatrace.OpenKit.Core
         }
 
         [Test]
+        public void ReportEventDoesNothingIfEventNameIsNull()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when reporting an event
+            var obtained = target.ReportEvent(null);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportEvent: eventName must not be null or empty");
+        }
+
+        [Test]
+        public void ReportEventDoesNothingIfEventNameIsAnEmptyString()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when reporting an event
+            var obtained = target.ReportEvent(string.Empty);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportEvent: eventName must not be null or empty");
+        }
+
+        [Test]
         public void ReportIntValue()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             beacon.ClearData();
 
             // when reporting an event
@@ -219,7 +257,7 @@ namespace Dynatrace.OpenKit.Core
         public void ReportIntValueDoesNothingIfActionIsLeft()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             target.LeaveAction();
             beacon.ClearData();
 
@@ -233,10 +271,48 @@ namespace Dynatrace.OpenKit.Core
         }
 
         [Test]
+        public void ReportIntValueDoesNothingIfValueNameIsNull()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            const int value = 42;
+            var obtained = target.ReportValue(null, value);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportValue (int): valueName must not be null or empty");
+        }
+
+        [Test]
+        public void ReportIntValueDoesNothingIfValueNameIsAnEmptyString()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            const int value = 42;
+            var obtained = target.ReportValue(string.Empty, value);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportValue (int): valueName must not be null or empty");
+        }
+
+        [Test]
         public void ReportDoubleValue()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             beacon.ClearData();
 
             // when reporting an event
@@ -252,7 +328,7 @@ namespace Dynatrace.OpenKit.Core
         public void ReportDoubleValueDoesNothingIfActionIsLeft()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             target.LeaveAction();
             beacon.ClearData();
 
@@ -266,10 +342,48 @@ namespace Dynatrace.OpenKit.Core
         }
 
         [Test]
+        public void ReportDoubleValueDoesNothingIfValueNameIsNull()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            const double value = 42.125;
+            var obtained = target.ReportValue(null, value);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportValue (double): valueName must not be null or empty");
+        }
+
+        [Test]
+        public void ReportDoubleValueDoesNothingIfValueNameIsAnEmptyString()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            const double value = 42.25;
+            var obtained = target.ReportValue(string.Empty, value);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportValue (double): valueName must not be null or empty");
+        }
+
+        [Test]
         public void ReportStringValue()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             beacon.ClearData();
 
             // when reporting an event
@@ -285,7 +399,7 @@ namespace Dynatrace.OpenKit.Core
         public void ReportStringValueDoesNothingIfActionIsLeft()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             target.LeaveAction();
             beacon.ClearData();
 
@@ -299,10 +413,63 @@ namespace Dynatrace.OpenKit.Core
         }
 
         [Test]
+        public void ReportStringValueDoesNothingIfValueNameIsNull()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            const string value = "42";
+            var obtained = target.ReportValue(null, value);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportValue (string): valueName must not be null or empty");
+        }
+
+        [Test]
+        public void ReportStringValueDoesNothingIfValueNameIsAnEmptyString()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            const string value = "42";
+            var obtained = target.ReportValue(string.Empty, value);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportValue (string): valueName must not be null or empty");
+        }
+
+        [Test]
+        public void ReportStringValueWithValueBeingNullWorks()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            var obtained = target.ReportValue("valueName", null);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.False);
+            Assert.That(obtained, Is.SameAs(target));
+        }
+
+        [Test]
         public void ReportError()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             beacon.ClearData();
 
             // when reporting an event
@@ -317,7 +484,7 @@ namespace Dynatrace.OpenKit.Core
         public void ReportErrorDoesNothingIfActionIsLeft()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             target.LeaveAction();
             beacon.ClearData();
 
@@ -330,10 +497,61 @@ namespace Dynatrace.OpenKit.Core
         }
 
         [Test]
+        public void ReportErrorDoesNothingIfErrorNameIsNull()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            var obtained = target.ReportError(null, 418, "I'm a teapot");
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportError: errorName must not be null or empty");
+        }
+
+        [Test]
+        public void ReportErrorDoesNothingIfErrorNameIsAnEmptyString()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            var obtained = target.ReportError(string.Empty, 418, "I'm a teapot");
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.SameAs(target));
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.reportError: errorName must not be null or empty");
+        }
+
+        [Test]
+        public void ReportErrorAcceptsNullReason()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            var obtained = target.ReportError("errorName", 418, null);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.False);
+            Assert.That(obtained, Is.SameAs(target));
+        }
+
+        [Test]
         public void TraceWebRequestGivesValidWebRequestTracer()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             beacon.ClearData();
 
             // when
@@ -348,7 +566,7 @@ namespace Dynatrace.OpenKit.Core
         public void TraceWebRequestGivesNullWebRequestTracerIfActionIsAlreadyLeft()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             target.LeaveAction();
             beacon.ClearData();
 
@@ -356,16 +574,51 @@ namespace Dynatrace.OpenKit.Core
             var obtained = target.TraceWebRequest("http://example.com/pages/");
 
             // then
-            Assert.That(obtained, Is.Not.Null);
-            Assert.That(obtained, Is.InstanceOf<NullWebRequestTracer>());
+            Assert.That(obtained, Is.Not.Null.And.InstanceOf<NullWebRequestTracer>());
+        }
+
+        [Test]
+        public void TraceWebRequestGivesNullWebRequestTracerIfUrlIsNull()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            var obtained = target.TraceWebRequest(null);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.Not.Null.And.InstanceOf<NullWebRequestTracer>());
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.traceWebRequest (String): url must not be null or empty");
+        }
+
+        [Test]
+        public void TraceWebRequestGivesNullWebRequestTracerIfUrlIsAnEmptyString()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            var obtained = target.TraceWebRequest(null);
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.Not.Null.And.InstanceOf<NullWebRequestTracer>());
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("Action.traceWebRequest (String): url must not be null or empty");
         }
 
         [Test]
         public void LeavingAnActionReturnsTheParentAction()
         {
             // given
-            var parent = new Action(beacon, "parent", new SynchronizedQueue<IAction>());
-            var child = new Action(beacon, "test", parent, new SynchronizedQueue<IAction>());
+            var parent = new Action(logger, beacon, "parent", new SynchronizedQueue<IAction>());
+            var child = new Action(logger, beacon, "test", parent, new SynchronizedQueue<IAction>());
 
             // when leaving the child action
             var obtained = child.LeaveAction();
@@ -386,7 +639,7 @@ namespace Dynatrace.OpenKit.Core
         {
             // given
             mockTimingProvider.ProvideTimestampInMilliseconds().Returns(123L, 321L, 322L, 323L);
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
 
             // when leaving the action
             target.LeaveAction();
@@ -400,7 +653,7 @@ namespace Dynatrace.OpenKit.Core
         public void LeavingAnActionSetsTheEndSequenceNumber()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             while (beacon.NextSequenceNumber < 41) ; // increase the sequence number
 
             // when leaving the action
@@ -414,7 +667,7 @@ namespace Dynatrace.OpenKit.Core
         public void LeavingAnActionAddsItselfInTheBeacon()
         {
             // given
-            var target = new Action(beacon, "test", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
             beacon.ClearData();
 
             // when leaving the action
@@ -429,7 +682,7 @@ namespace Dynatrace.OpenKit.Core
         {
             // given
             var actions = new SynchronizedQueue<IAction>();
-            var target = new Action(beacon, "test", actions);
+            var target = new Action(logger, beacon, "test", actions);
 
             // when leaving the action
             target.LeaveAction();
@@ -443,8 +696,8 @@ namespace Dynatrace.OpenKit.Core
         {
             // given
             mockTimingProvider.ProvideTimestampInMilliseconds().Returns(123L, 321L, 322L, 323L, 324L, 325L);
-            var parent = new Action(beacon, "parent", new SynchronizedQueue<IAction>());
-            var target = new Action(beacon, "test", parent, new SynchronizedQueue<IAction>());
+            var parent = new Action(logger, beacon, "parent", new SynchronizedQueue<IAction>());
+            var target = new Action(logger, beacon, "test", parent, new SynchronizedQueue<IAction>());
 
             // when leaving the action first time
             var obtained = target.LeaveAction();
@@ -471,7 +724,7 @@ namespace Dynatrace.OpenKit.Core
             // given
             var actions = new SynchronizedQueue<IAction>();
             mockTimingProvider.ProvideTimestampInMilliseconds().Returns(123L, 321L, 322L, 323L);
-            IDisposable target = new Action(beacon, "test", actions);
+            IDisposable target = new Action(logger, beacon, "test", actions);
             while (beacon.NextSequenceNumber < 41) ; // increase the sequence number
 
             // when disposing the target

--- a/tests/openkit-shared-tests/Core/Communication/BeaconSendingCaptureOnStateTest.cs
+++ b/tests/openkit-shared-tests/Core/Communication/BeaconSendingCaptureOnStateTest.cs
@@ -288,7 +288,8 @@ namespace Dynatrace.OpenKit.Core.Communication
 
         private Session CreateValidSession(string clientIP)
         {
-            var session = new Session(beaconSender, new Beacon(Substitute.For<ILogger>(), new BeaconCache(), 
+            var logger = Substitute.For<ILogger>();
+            var session = new Session(logger, beaconSender, new Beacon(logger, new BeaconCache(), 
                 config, clientIP, Substitute.For<IThreadIDProvider>(), timingProvider));
 
             session.EnterAction("Foo").LeaveAction();
@@ -298,7 +299,8 @@ namespace Dynatrace.OpenKit.Core.Communication
 
         private Session CreateEmptySession(string clientIP)
         {
-            return new Session(beaconSender, new Beacon(Substitute.For<ILogger>(), new BeaconCache(),
+            var logger = Substitute.For<ILogger>();
+            return new Session(logger, beaconSender, new Beacon(logger, new BeaconCache(),
                 config, clientIP, Substitute.For<IThreadIDProvider>(), timingProvider));
         }
     }

--- a/tests/openkit-shared-tests/Core/Communication/BeaconSendingContextTest.cs
+++ b/tests/openkit-shared-tests/Core/Communication/BeaconSendingContextTest.cs
@@ -305,9 +305,10 @@ namespace Dynatrace.OpenKit.Core.Communication
         public void SessionIsMovedToFinished()
         {
             // given
+            var logger = Substitute.For<ILogger>();
             var target = new BeaconSendingContext(config, clientProvider, timingProvider);
 
-            var session = new Session(new BeaconSender(target), new Beacon(Substitute.For<ILogger>(), new BeaconCache(),
+            var session = new Session(logger, new BeaconSender(target), new Beacon(logger, new BeaconCache(),
                 config, "127.0.0.1", Substitute.For<IThreadIDProvider>(), timingProvider));
 
             Assert.That(target.GetAllOpenSessions().Count, Is.EqualTo(1));

--- a/tests/openkit-shared-tests/Core/Communication/BeaconSendingFlushSessionsStateTest.cs
+++ b/tests/openkit-shared-tests/Core/Communication/BeaconSendingFlushSessionsStateTest.cs
@@ -99,7 +99,8 @@ namespace Dynatrace.OpenKit.Core.Communication
 
         private Session CreateValidSession(string clientIP)
         {
-            var session = new Session(beaconSender, new Beacon(Substitute.For<ILogger>(), new BeaconCache(),
+            var logger = Substitute.For<ILogger>();
+            var session = new Session(logger, beaconSender, new Beacon(logger, new BeaconCache(),
                 new TestConfiguration(), clientIP, Substitute.For<IThreadIDProvider>(), timingProvider));
 
             session.EnterAction("Foo").LeaveAction();

--- a/tests/openkit-shared-tests/Core/RootActionTest.cs
+++ b/tests/openkit-shared-tests/Core/RootActionTest.cs
@@ -26,13 +26,15 @@ namespace Dynatrace.OpenKit.Core
     public class RootActionTest
     {
         private ITimingProvider mockTimingProvider;
+        private ILogger logger;
         private Beacon beacon;
 
         [SetUp]
         public void SetUp()
         {
             mockTimingProvider = Substitute.For<ITimingProvider>();
-            beacon = new Beacon(Substitute.For<ILogger>(),
+            logger = Substitute.For<ILogger>();
+            beacon = new Beacon(logger,
                                 new BeaconCache(),
                                 new TestConfiguration(),
                                 "127.0.0.1",
@@ -44,22 +46,20 @@ namespace Dynatrace.OpenKit.Core
         public void EnterActionReturnsNewChildAction()
         {
             // given
-            var target = new RootAction(beacon, "root action", new SynchronizedQueue<IAction>());
+            var target = new RootAction(logger, beacon, "root action", new SynchronizedQueue<IAction>());
 
             // when entering first child
             var childOne = target.EnterAction("child one");
 
             // then
-            Assert.That(childOne, Is.Not.Null);
-            Assert.That(childOne, Is.TypeOf<Action>());
+            Assert.That(childOne, Is.Not.Null.And.TypeOf<Action>());
             Assert.That(((Action)childOne).ParentID, Is.EqualTo(target.ID));
 
             // when entering second child
             var childTwo = target.EnterAction("child one");
 
             // then
-            Assert.That(childTwo, Is.Not.Null);
-            Assert.That(childTwo, Is.TypeOf<Action>());
+            Assert.That(childTwo, Is.Not.Null.And.TypeOf<Action>());
             Assert.That(((Action)childTwo).ParentID, Is.EqualTo(target.ID));
             Assert.That(childTwo, Is.Not.SameAs(childOne));
         }
@@ -68,23 +68,53 @@ namespace Dynatrace.OpenKit.Core
         public void EnterActionReturnsNullActionIfAlreadyLeft()
         {
             // given
-            var target = new RootAction(beacon, "root action", new SynchronizedQueue<IAction>());
+            var target = new RootAction(logger, beacon, "root action", new SynchronizedQueue<IAction>());
             target.LeaveAction();
 
             // when entering first child
             var childOne = target.EnterAction("child one");
 
             // then
-            Assert.That(childOne, Is.Not.Null);
-            Assert.That(childOne, Is.TypeOf<NullAction>());
+            Assert.That(childOne, Is.Not.Null.And.TypeOf<NullAction>());
 
             // when entering second child
             var childTwo = target.EnterAction("child one");
 
             // then
-            Assert.That(childTwo, Is.Not.Null);
-            Assert.That(childTwo, Is.TypeOf<NullAction>());
+            Assert.That(childTwo, Is.Not.Null.And.TypeOf<NullAction>());
             Assert.That(childTwo, Is.Not.SameAs(childOne));
+        }
+
+        [Test]
+        public void EnterActionReturnsNullActionIfActionNameIsNull()
+        {
+            // given
+            var target = new RootAction(logger, beacon, "root action", new SynchronizedQueue<IAction>());
+
+            // when
+            var childOne = target.EnterAction(null);
+
+            // then
+            Assert.That(childOne, Is.Not.Null.And.TypeOf<NullAction>());
+            
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("RootAction.enterAction: actionName must not be null or empty");
+        }
+
+        [Test]
+        public void EnterActionReturnsNullActionIfActionNameIsAnEmptyString()
+        {
+            // given
+            var target = new RootAction(logger, beacon, "root action", new SynchronizedQueue<IAction>());
+
+            // when
+            var childOne = target.EnterAction(string.Empty);
+
+            // then
+            Assert.That(childOne, Is.Not.Null.And.TypeOf<NullAction>());
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn("RootAction.enterAction: actionName must not be null or empty");
         }
 
         [Test]
@@ -97,7 +127,7 @@ namespace Dynatrace.OpenKit.Core
                 startTimestamp += 1;
                 return startTimestamp;
             });
-            var target = new RootAction(beacon, "root action", new SynchronizedQueue<IAction>());
+            var target = new RootAction(logger, beacon, "root action", new SynchronizedQueue<IAction>());
 
             var childActionOne = target.EnterAction("child one");
             var childActionTwo = target.EnterAction("child two");
@@ -118,7 +148,7 @@ namespace Dynatrace.OpenKit.Core
         public void LeavingRootActionReturnsNullValueAsParent()
         {
             // given
-            var target = new RootAction(beacon, "root action", new SynchronizedQueue<IAction>());
+            var target = new RootAction(logger, beacon, "root action", new SynchronizedQueue<IAction>());
 
             // when
             var obtained = target.LeaveAction();

--- a/tests/openkit-shared-tests/Core/RootActionTest.cs
+++ b/tests/openkit-shared-tests/Core/RootActionTest.cs
@@ -98,7 +98,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(childOne, Is.Not.Null.And.TypeOf<NullAction>());
             
             // also verify that warning has been written to log
-            logger.Received(1).Warn("RootAction.enterAction: actionName must not be null or empty");
+            logger.Received(1).Warn("RootAction.EnterAction: actionName must not be null or empty");
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(childOne, Is.Not.Null.And.TypeOf<NullAction>());
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("RootAction.enterAction: actionName must not be null or empty");
+            logger.Received(1).Warn("RootAction.EnterAction: actionName must not be null or empty");
         }
 
         [Test]

--- a/tests/openkit-shared-tests/Core/SessionTest.cs
+++ b/tests/openkit-shared-tests/Core/SessionTest.cs
@@ -121,7 +121,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.Not.Null.And.TypeOf<NullRootAction>());
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Session.enterAction: actionName must not be null or empty");
+            logger.Received(1).Warn("Session.EnterAction: actionName must not be null or empty");
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(obtained, Is.Not.Null.And.TypeOf<NullRootAction>());
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Session.enterAction: actionName must not be null or empty");
+            logger.Received(1).Warn("Session.EnterAction: actionName must not be null or empty");
         }
 
         [Test]
@@ -183,7 +183,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(beacon.IsEmpty, Is.True);
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Session.identifyUser: userTag must not be null or empty");
+            logger.Received(1).Warn("Session.IdentifyUser: userTag must not be null or empty");
         }
 
         [Test]
@@ -200,7 +200,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(beacon.IsEmpty, Is.True);
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Session.identifyUser: userTag must not be null or empty");
+            logger.Received(1).Warn("Session.IdentifyUser: userTag must not be null or empty");
         }
 
         [Test]
@@ -246,7 +246,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(beacon.IsEmpty, Is.True);
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Session.reportCrash: errorName must not be null or empty");
+            logger.Received(1).Warn("Session.ReportCrash: errorName must not be null or empty");
         }
 
         [Test]
@@ -263,7 +263,7 @@ namespace Dynatrace.OpenKit.Core
             Assert.That(beacon.IsEmpty, Is.True);
 
             // also verify that warning has been written to log
-            logger.Received(1).Warn("Session.reportCrash: errorName must not be null or empty");
+            logger.Received(1).Warn("Session.ReportCrash: errorName must not be null or empty");
         }
 
         [Test]

--- a/tests/openkit-shared-tests/Core/WebRequestTracerBaseTest.cs
+++ b/tests/openkit-shared-tests/Core/WebRequestTracerBaseTest.cs
@@ -35,15 +35,16 @@ namespace Dynatrace.OpenKit.Core
         [SetUp]
         public void SetUp()
         {
+            var logger = Substitute.For<ILogger>();
             mockTimingProvider = Substitute.For<ITimingProvider>();
             testConfiguration = new TestConfiguration();
-            beacon = new Beacon(Substitute.For<ILogger>(),
+            beacon = new Beacon(logger,
                                 new BeaconCache(),
                                 testConfiguration,
                                 "127.0.0.1",
                                 Substitute.For<IThreadIDProvider>(),
                                 mockTimingProvider);
-            action = new RootAction(beacon, "ActionName", new SynchronizedQueue<IAction>());
+            action = new RootAction(logger, beacon, "ActionName", new SynchronizedQueue<IAction>());
         }
 
         [Test]

--- a/tests/openkit-shared-tests/Protocol/BeaconTest.cs
+++ b/tests/openkit-shared-tests/Protocol/BeaconTest.cs
@@ -27,19 +27,21 @@ namespace Dynatrace.OpenKit.Protocol
     {
         private IThreadIDProvider threadIdProvider;
         private ITimingProvider timingProvider;
+        private ILogger logger;
 
         [SetUp]
         public void Setup()
         {
             threadIdProvider = Substitute.For<IThreadIDProvider>();
             timingProvider = Substitute.For<ITimingProvider>();
+            logger = Substitute.For<ILogger>();
         }
 
         [Test]
         public void CanAddUserIdentifyEvent()
         {
             // given
-            var beacon = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var beacon = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
             var userTag = "myTestUser";
 
             // when
@@ -54,8 +56,8 @@ namespace Dynatrace.OpenKit.Protocol
         public void CanAddSentBytesToWebRequestTracer()
         {
             //given
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
-            var action = new Action(target, "TestRootAction", new SynchronizedQueue<IAction>());
+            var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
             var testURL = "127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesSent = 123;
@@ -71,8 +73,8 @@ namespace Dynatrace.OpenKit.Protocol
         public void CanAddSentBytesValueZeroToWebRequestTracer()
         {
             //given
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
-            var action = new Action(target, "TestRootAction", new SynchronizedQueue<IAction>());
+            var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
             var testURL = "127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesSent = 0;
@@ -88,8 +90,8 @@ namespace Dynatrace.OpenKit.Protocol
         public void CannotAddSentBytesWithInvalidValueSmallerZeroToWebRequestTracer()
         {
             //given
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
-            var action = new Action(target, "TestRootAction", new SynchronizedQueue<IAction>());
+            var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
             var testURL = "127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
 
@@ -104,8 +106,8 @@ namespace Dynatrace.OpenKit.Protocol
         public void CanAddReceivedBytesToWebRequestTracer()
         {
             //given
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
-            var action = new Action(target, "TestRootAction", new SynchronizedQueue<IAction>());
+            var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
             var testURL = "127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesReceived = 12321;
@@ -121,8 +123,8 @@ namespace Dynatrace.OpenKit.Protocol
         public void CanAddReceivedBytesValueZeroToWebRequestTracer()
         {
             //given
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
-            var action = new Action(target, "TestRootAction", new SynchronizedQueue<IAction>());
+            var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
             var testURL = "127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesReceived = 0;
@@ -138,8 +140,8 @@ namespace Dynatrace.OpenKit.Protocol
         public void CannotAddReceivedBytesWithInvalidValueSmallerZeroToWebRequestTracer()
         {
             //given
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
-            var action = new Action(target, "TestRootAction", new SynchronizedQueue<IAction>());
+            var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
             var testURL = "127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
 
@@ -154,8 +156,8 @@ namespace Dynatrace.OpenKit.Protocol
         public void CanAddBothSentBytesAndReceivedBytesToWebRequestTracer()
         {
             //given
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
-            var action = new Action(target, "TestRootAction", new SynchronizedQueue<IAction>());
+            var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
             var testURL = "127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesReceived = 12321;
@@ -175,13 +177,13 @@ namespace Dynatrace.OpenKit.Protocol
             var configuration = new TestConfiguration();
             configuration.EnableCapture();
 
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), 
+            var target = new Beacon(logger, new BeaconCache(), 
                 configuration, "127.0.0.1", threadIdProvider, timingProvider);
             const string RootActionName = "TestRootAction";
 
 
             // when adding the root action
-            var action = new RootAction(target, RootActionName, new SynchronizedQueue<IAction>()); // the action is added to the beacon in the constructor
+            var action = new RootAction(logger, target, RootActionName, new SynchronizedQueue<IAction>()); // the action is added to the beacon in the constructor
             action.LeaveAction();
 
             // then
@@ -195,12 +197,12 @@ namespace Dynatrace.OpenKit.Protocol
             var configuration = new TestConfiguration();
             configuration.DisableCapture();
 
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), 
+            var target = new Beacon(logger, new BeaconCache(), 
                 configuration, "127.0.0.1", threadIdProvider, timingProvider);
 
             // when adding the root action
             const string RootActionName = "TestRootAction";
-            target.AddAction(new RootAction(target, RootActionName, new SynchronizedQueue<IAction>()));
+            target.AddAction(new RootAction(logger, target, RootActionName, new SynchronizedQueue<IAction>()));
 
             // then
             Assert.That(target.ActionDataList, Is.Empty);
@@ -210,8 +212,8 @@ namespace Dynatrace.OpenKit.Protocol
         public void ClearDataClearsActionAndEventData()
         {
             // given
-            var target = new Beacon(Substitute.For<ILogger>(), new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
-            var action = new Action(target, "TestAction", new SynchronizedQueue<IAction>());
+            var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
+            var action = new Action(logger, target, "TestAction", new SynchronizedQueue<IAction>());
             action.ReportEvent("TestEvent").ReportValue("TheAnswerToLifeTheUniverseAndEverything", 42);
             target.AddAction(action);
 


### PR DESCRIPTION
For certain OpenKit objects null/empty string parameters cannot be
handled or do not make sense.
Therefore they check for such arugments and log warnings or return
NullObjects.