### PR TITLE
Validate URL schemes when tracing web requests

### DIFF
--- a/src/openkit-shared/Core/Action.cs
+++ b/src/openkit-shared/Core/Action.cs
@@ -161,6 +161,11 @@ namespace Dynatrace.OpenKit.Core
                 logger.Warn("Action.TraceWebRequest (String): url must not be null or empty");
                 return NullWebRequestTracer;
             }
+            if (!WebRequestTracerStringURL.IsValidURLScheme(url))
+            {
+                logger.Warn($"Action.TraceWebRequest (String): url \"{url}\" does not have a valid scheme");
+                return NullWebRequestTracer;
+            }
             if (!IsActionLeft)
             {
                 return new WebRequestTracerStringURL(beacon, this, url);

--- a/src/openkit-shared/Core/WebRequestTracerStringURL.cs
+++ b/src/openkit-shared/Core/WebRequestTracerStringURL.cs
@@ -15,7 +15,7 @@
 //
 
 using Dynatrace.OpenKit.Protocol;
-using System;
+using System.Text.RegularExpressions;
 
 namespace Dynatrace.OpenKit.Core
 {
@@ -27,17 +27,22 @@ namespace Dynatrace.OpenKit.Core
     public class WebRequestTracerStringURL : WebRequestTracerBase
     {
 
+        private static readonly Regex SchemaValidationPattern = new Regex("^[a-z][a-z0-9+\\-.]*://.+", 
+                                                                          RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         // *** constructors ***
 
         public WebRequestTracerStringURL(Beacon beacon, Action action, string url) : base(beacon, action)
         {
-            this.url = url;
-
             // separate query string from URL
-            if (url != null)
+            if (IsValidURLScheme(url))
             {
-                this.url = url.Split(new Char[] { '?' })[0];
+                this.url = url.Split(new char[] { '?' }, 2)[0];
             }
+        }
+        internal static bool IsValidURLScheme(string url)
+        {
+            return url != null && SchemaValidationPattern.Match(url).Success;
         }
 
     }

--- a/tests/openkit-shared-tests/Core/ActionTest.cs
+++ b/tests/openkit-shared-tests/Core/ActionTest.cs
@@ -603,7 +603,7 @@ namespace Dynatrace.OpenKit.Core
             beacon.ClearData();
 
             // when
-            var obtained = target.TraceWebRequest(null);
+            var obtained = target.TraceWebRequest(string.Empty);
 
             // then
             Assert.That(beacon.IsEmpty, Is.True);
@@ -611,6 +611,24 @@ namespace Dynatrace.OpenKit.Core
 
             // also verify that warning has been written to log
             logger.Received(1).Warn("Action.TraceWebRequest (String): url must not be null or empty");
+        }
+
+        [Test]
+        public void TraceWebRequestGivesNullWebRequestTracerIfUrlHasAnInvalidScheme()
+        {
+            // given
+            var target = new Action(logger, beacon, "test", new SynchronizedQueue<IAction>());
+            beacon.ClearData();
+
+            // when
+            var obtained = target.TraceWebRequest("foo:bar://test.com");
+
+            // then
+            Assert.That(beacon.IsEmpty, Is.True);
+            Assert.That(obtained, Is.Not.Null.And.InstanceOf<NullWebRequestTracer>());
+
+            // also verify that warning has been written to log
+            logger.Received(1).Warn($"Action.TraceWebRequest (String): url \"foo:bar://test.com\" does not have a valid scheme");
         }
 
         [Test]

--- a/tests/openkit-shared-tests/Core/WebRequestTracerStringURLTest.cs
+++ b/tests/openkit-shared-tests/Core/WebRequestTracerStringURLTest.cs
@@ -1,0 +1,109 @@
+﻿//
+// Copyright 2018 Dynatrace LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using Dynatrace.OpenKit.API;
+using Dynatrace.OpenKit.Core.Caching;
+using Dynatrace.OpenKit.Protocol;
+using Dynatrace.OpenKit.Providers;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Dynatrace.OpenKit.Core
+{
+    public class WebRequestTracerStringURLTest
+    {
+        private Beacon beacon;
+        private Action action;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var logger = Substitute.For<ILogger>();
+            beacon = new Beacon(logger,
+                                new BeaconCache(),
+                                new TestConfiguration(),
+                                "127.0.0.1",
+                                Substitute.For<IThreadIDProvider>(),
+                                Substitute.For<ITimingProvider>());
+            action = new RootAction(logger, beacon, "ActionName", new SynchronizedQueue<IAction>());
+        }
+
+        [Test]
+        public void NullIsNotAValidURLScheme()
+        {
+            // then
+            Assert.That(WebRequestTracerStringURL.IsValidURLScheme(null), Is.False);
+        }
+
+        [Test]
+        public void AValidSchemeStartsWithALetter()
+        {
+            // when starting with lower case letter, then
+            Assert.That(WebRequestTracerStringURL.IsValidURLScheme("a://some.host"), Is.True);
+        }
+
+        [Test]
+        public void AValidSchemeOnlyContainsLettersDigitsPlusPeriodOrHyphen()
+        {
+            // when the url scheme contains all allowed characters
+            Assert.That(WebRequestTracerStringURL.IsValidURLScheme("b1+Z6.-://some.host"), Is.True);
+        }
+
+        [Test]
+        public void AValidSchemeAllowsUpperCaseLettersToo()
+        {
+
+            // when the url scheme contains all allowed characters
+            Assert.That(WebRequestTracerStringURL.IsValidURLScheme("Obp1e+nZK6i.t-://some.host"), Is.True);
+        }
+
+        [Test]
+        public void AValidSchemeDoesNotStartWithADigit()
+        {
+            // when it does not start with a digit, then it's valid
+            Assert.That(WebRequestTracerStringURL.IsValidURLScheme("a1://some.host"), Is.True);
+            // when it starts with a digit, then it's invalid
+            Assert.That(WebRequestTracerStringURL.IsValidURLScheme("1a://some.host"), Is.False);
+        }
+
+        [Test]
+        public void ASchemeIsInvalidIfInvalidCharactersAreEncountered()
+        {
+            // then
+            Assert.That(WebRequestTracerStringURL.IsValidURLScheme("a()[]{}@://some.host"), Is.False);
+        }
+
+        [Test]
+        public void AnURLIsOnlySetInConstructorIfItIsValid()
+        {
+            // given
+            var target = new WebRequestTracerStringURL(beacon, action, "a1337://foo");
+
+            // then
+            Assert.That(target.URL, Is.EqualTo("a1337://foo"));
+        }
+
+        [Test]
+        public void IfURLIsInvalidTheDefaultValueIsUsed()
+        {
+            // given
+            var target = new WebRequestTracerStringURL(beacon, action, "foobar");
+
+            // then
+            Assert.That(target.URL, Is.EqualTo("<unknown>"));
+        }
+    }
+}

--- a/tests/openkit-shared-tests/Protocol/BeaconTest.cs
+++ b/tests/openkit-shared-tests/Protocol/BeaconTest.cs
@@ -58,7 +58,7 @@ namespace Dynatrace.OpenKit.Protocol
             //given
             var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "127.0.0.1";
+            var testURL = "https://127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesSent = 123;
 
@@ -66,7 +66,7 @@ namespace Dynatrace.OpenKit.Protocol
             webRequest.Start().SetBytesSent(bytesSent).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={testURL}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs={bytesSent}" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs={bytesSent}" }));
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace Dynatrace.OpenKit.Protocol
             //given
             var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "127.0.0.1";
+            var testURL = "https://127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesSent = 0;
 
@@ -83,7 +83,7 @@ namespace Dynatrace.OpenKit.Protocol
             webRequest.Start().SetBytesSent(bytesSent).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={testURL}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs={bytesSent}" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs={bytesSent}" }));
         }
 
         [Test]
@@ -92,14 +92,14 @@ namespace Dynatrace.OpenKit.Protocol
             //given
             var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "127.0.0.1";
+            var testURL = "https://127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
 
             //when
             webRequest.Start().SetBytesSent(-1).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={testURL}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0" }));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace Dynatrace.OpenKit.Protocol
             //given
             var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "127.0.0.1";
+            var testURL = "https://127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesReceived = 12321;
 
@@ -116,7 +116,7 @@ namespace Dynatrace.OpenKit.Protocol
             webRequest.Start().SetBytesReceived(bytesReceived).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={testURL}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&br={bytesReceived}" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&br={bytesReceived}" }));
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace Dynatrace.OpenKit.Protocol
             //given
             var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "127.0.0.1";
+            var testURL = "https://127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesReceived = 0;
 
@@ -133,7 +133,7 @@ namespace Dynatrace.OpenKit.Protocol
             webRequest.Start().SetBytesReceived(bytesReceived).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={testURL}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&br={bytesReceived}" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&br={bytesReceived}" }));
         }
 
         [Test]
@@ -142,14 +142,14 @@ namespace Dynatrace.OpenKit.Protocol
             //given
             var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "127.0.0.1";
+            var testURL = "https://127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
 
             //when
             webRequest.Start().SetBytesReceived(-1).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={testURL}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0" }));
         }
 
         [Test]
@@ -158,7 +158,7 @@ namespace Dynatrace.OpenKit.Protocol
             //given
             var target = new Beacon(logger, new BeaconCache(), new TestConfiguration(), "127.0.0.1", threadIdProvider, timingProvider);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "127.0.0.1";
+            var testURL = "https://127.0.0.1";
             var webRequest = new WebRequestTracerStringURL(target, action, testURL);
             var bytesReceived = 12321;
             var bytesSent = 123;
@@ -167,7 +167,7 @@ namespace Dynatrace.OpenKit.Protocol
             webRequest.Start().SetBytesSent(bytesSent).SetBytesReceived(bytesReceived).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={testURL}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs=123&br=12321" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs=123&br=12321" }));
         }
 
         [Test]

--- a/tests/openkit-shared-tests/openkit-shared-tests.projitems
+++ b/tests/openkit-shared-tests/openkit-shared-tests.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\RootActionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\SessionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\WebRequestTracerBaseTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\WebRequestTracerStringURLTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OpenKitBuilderTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Protocol\BeaconTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Util\InetAddressValidatorTest.cs" />


### PR DESCRIPTION
Validate that the scheme of the given String URL to
trace conforms to RFC3986 and that it contains
at least some character after the delimiting ://