### PR TITLE
Make all OpenKit threads Background threads

### DIFF
--- a/src/openkit-shared/Core/BeaconSender.cs
+++ b/src/openkit-shared/Core/BeaconSender.cs
@@ -67,6 +67,7 @@ namespace Dynatrace.OpenKit.Core
                     context.ExecuteCurrentState();
                 }
             }));
+            beaconSenderThread.IsBackground = true;
             // start thread
             beaconSenderThread.Start();
 

--- a/src/openkit-shared/Core/Caching/BeaconCacheEvictor.cs
+++ b/src/openkit-shared/Core/Caching/BeaconCacheEvictor.cs
@@ -70,8 +70,11 @@ namespace Dynatrace.OpenKit.Core.Caching
             this.logger = logger;
             this.beaconCache = beaconCache;
             this.strategies = strategies;
-            evictionThread = new Thread(RunEvictionThread);
-            evictionThread.Name = this.GetType().Name;
+            evictionThread = new Thread(RunEvictionThread)
+            {
+                Name = this.GetType().Name,
+                IsBackground = true
+            };
 
         }
 


### PR DESCRIPTION
If OpenKit threads are non-background and the client application does
not shutdown OpenKit properly then OpenKit would stall the client
application.
Background threads are used to avoid that potential problems.