### PR TITLE
Add OpenKit .NET Standard 2.0 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ for:
   test_script:
   - ps: |
       # Run .NET test assemblies, excluding .NET Core
-      $testAssemblies = Get-ChildItem -Recurse -Include openkit-dotnetfull-*Tests.dll  | ? {$_.FullName -match "\\bin\\Coverage\\" } | % FullName 
+      $testAssemblies = Get-ChildItem -Recurse -Include openkit-dotnetfull-*Tests.dll,openkit-dotnetstandard-*Tests.dll  | ? {$_.FullName -match "\\bin\\Coverage\\" } | % FullName 
       packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"packages\NUnit.ConsoleRunner.3.8.0\tools\nunit3-console.exe" -targetargs:"'--result=myresults.xml;format=AppVeyor' $testAssemblies" -register:user -filter:"+[*]* -[*.Tests]*" -output:coverage.xml
       # Run .NET Core tests
       $testProjects = Get-ChildItem -Recurse -Include openkit-dotnetcore-*Tests.csproj  | % FullName

--- a/openkit-dotnet.sln
+++ b/openkit-dotnet.sln
@@ -55,11 +55,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "openkit-dotnetcore-1.1", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "openkit-dotnetcore-1.1.Tests", "tests\openkit-dotnetcore-1.1.Tests\openkit-dotnetcore-1.1.Tests.csproj", "{C4776626-4FCA-4A2B-8314-22EBDAAADEDF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "openkit-dotnetstandard-2.0", "src\openkit-dotnetstandard-2.0\openkit-dotnetstandard-2.0.csproj", "{38D50AAF-C5AA-47CC-8792-661BA456CB6E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "openkit-dotnetstandard-2.0.Tests", "tests\openkit-dotnetstandard-2.0.Tests\openkit-dotnetstandard-2.0.Tests.csproj", "{5E36E80F-298C-4378-8E31-FCC7C73C4233}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tests\openkit-shared-tests\openkit-shared-tests.projitems*{0dee56ca-e460-488f-900e-35bdef9e890c}*SharedItemsImports = 4
 		src\openkit-shared\openkit-shared.projitems*{3e70e67c-82bc-4320-b5f5-6f60314f7fe0}*SharedItemsImports = 4
 		tests\openkit-shared-tests\openkit-shared-tests.projitems*{48f4fb14-cc59-44b1-83da-b85d9e2a1ccb}*SharedItemsImports = 13
+		tests\openkit-shared-tests\openkit-shared-tests.projitems*{5e36e80f-298c-4378-8e31-fcc7c73c4233}*SharedItemsImports = 4
 		src\openkit-shared\openkit-shared.projitems*{72d1e225-8465-486d-9e36-a2cf09f26a00}*SharedItemsImports = 4
 		tests\openkit-shared-tests\openkit-shared-tests.projitems*{7394f6aa-300d-4fb0-bb2c-9cb22dabd514}*SharedItemsImports = 4
 		tests\openkit-shared-tests\openkit-shared-tests.projitems*{8b8fae28-f255-4391-8370-31dd894011c2}*SharedItemsImports = 4
@@ -469,6 +474,54 @@ Global
 		{C4776626-4FCA-4A2B-8314-22EBDAAADEDF}.Release|x64.Build.0 = Release|Any CPU
 		{C4776626-4FCA-4A2B-8314-22EBDAAADEDF}.Release|x86.ActiveCfg = Release|Any CPU
 		{C4776626-4FCA-4A2B-8314-22EBDAAADEDF}.Release|x86.Build.0 = Release|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Coverage|Any CPU.ActiveCfg = Coverage|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Coverage|Any CPU.Build.0 = Coverage|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Coverage|ARM.ActiveCfg = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Coverage|ARM.Build.0 = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Coverage|x64.ActiveCfg = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Coverage|x64.Build.0 = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Coverage|x86.ActiveCfg = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Coverage|x86.Build.0 = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Debug|ARM.Build.0 = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Debug|x64.Build.0 = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Debug|x86.Build.0 = Debug|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Release|ARM.ActiveCfg = Release|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Release|ARM.Build.0 = Release|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Release|x64.ActiveCfg = Release|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Release|x64.Build.0 = Release|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Release|x86.ActiveCfg = Release|Any CPU
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E}.Release|x86.Build.0 = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Coverage|Any CPU.ActiveCfg = Coverage|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Coverage|Any CPU.Build.0 = Coverage|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Coverage|ARM.ActiveCfg = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Coverage|ARM.Build.0 = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Coverage|x64.ActiveCfg = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Coverage|x64.Build.0 = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Coverage|x86.ActiveCfg = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Coverage|x86.Build.0 = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Debug|ARM.Build.0 = Debug|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Debug|x64.Build.0 = Debug|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Debug|x86.Build.0 = Debug|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Release|ARM.ActiveCfg = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Release|ARM.Build.0 = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Release|x64.ActiveCfg = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Release|x64.Build.0 = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Release|x86.ActiveCfg = Release|Any CPU
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -493,6 +546,8 @@ Global
 		{EF67A403-C30B-4382-B866-02288391031D} = {81668216-FD7D-4E19-9538-AA168F4AA12B}
 		{1F5A0303-9A83-4398-A1EF-9E4A9545CEDF} = {B14F89FD-EBF4-4DEB-9833-F2C4E4407C55}
 		{C4776626-4FCA-4A2B-8314-22EBDAAADEDF} = {81668216-FD7D-4E19-9538-AA168F4AA12B}
+		{38D50AAF-C5AA-47CC-8792-661BA456CB6E} = {B14F89FD-EBF4-4DEB-9833-F2C4E4407C55}
+		{5E36E80F-298C-4378-8E31-FCC7C73C4233} = {81668216-FD7D-4E19-9538-AA168F4AA12B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F480439E-DC91-4B89-853A-4BBA4C5539F1}

--- a/src/openkit-dotnetstandard-2.0/openkit-dotnetstandard-2.0.csproj
+++ b/src/openkit-dotnetstandard-2.0/openkit-dotnetstandard-2.0.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Dynatrace.OpenKit</RootNamespace>
+    <AssemblyName>openkit-1.2.0-SNAPSHOT-dotnetstandard-2.0</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Configurations>Debug;Release;Coverage</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Coverage|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  
+  <Import Project="..\openkit-shared\openkit-shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/openkit-shared/AssemblyInfo.cs
+++ b/src/openkit-shared/AssemblyInfo.cs
@@ -57,5 +57,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("openkit-dotnetfull-4.5.Tests")]
 [assembly: InternalsVisibleTo("openkit-dotnetfull-4.6.Tests")]
 [assembly: InternalsVisibleTo("openkit-dotnetfull-4.7.Tests")]
+[assembly: InternalsVisibleTo("openkit-dotnetstandard-2.0.Tests")]
 // Expose internal classes to NSubstitute
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/openkit-shared/Protocol/HTTPClientHttpClient.cs
+++ b/src/openkit-shared/Protocol/HTTPClientHttpClient.cs
@@ -31,6 +31,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
 #if NETSTANDARD2_0
             // for .NET standard the certificate validation callback needs to be set globally
+            // the other methods do not compile or throw NotImplementedException
             if (!RemoteCertificateValidationCallbackInitialized)
             {
                 System.Net.ServicePointManager.ServerCertificateValidationCallback += configuration.SSLTrustManager?.ServerCertificateValidationCallback;

--- a/tests/openkit-dotnetstandard-2.0.Tests/app.config
+++ b/tests/openkit-dotnetstandard-2.0.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/openkit-dotnetstandard-2.0.Tests/openkit-dotnetstandard-2.0.Tests.csproj
+++ b/tests/openkit-dotnetstandard-2.0.Tests/openkit-dotnetstandard-2.0.Tests.csproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5E36E80F-298C-4378-8E31-FCC7C73C4233}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Dynatrace.OpenKit</RootNamespace>
+    <AssemblyName>openkit-dotnetstandard-2.0.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Coverage|AnyCPU'">
+    <OutputPath>bin\Coverage\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\openkit-dotnetstandard-2.0\openkit-dotnetstandard-2.0.csproj">
+      <Project>{38d50aaf-c5aa-47cc-8792-661ba456cb6e}</Project>
+      <Name>openkit-dotnetstandard-2.0</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\openkit-shared-tests\openkit-shared-tests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
+</Project>

--- a/tests/openkit-dotnetstandard-2.0.Tests/packages.config
+++ b/tests/openkit-dotnetstandard-2.0.Tests/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
+  <package id="coveralls.io" version="1.4.2" targetFramework="net461" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+  <package id="NUnit.ConsoleRunner" version="3.8.0" targetFramework="net461" />
+  <package id="OpenCover" version="4.6.519" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
This is mainly intended for mobile applications,
such as Xamarin applications targeting ANdroid, iOS and such.
But this can alos be used for .NET Core 2.0 applications as well as .NET
Standard 4.6.1 apps.