### PR TITLE
Fix session start time

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.1.{build}
+version: 1.2.0.{build}
 
 # environment variables
 environment:

--- a/src/openkit-shared/AbstractOpenKitBuilder.cs
+++ b/src/openkit-shared/AbstractOpenKitBuilder.cs
@@ -86,11 +86,17 @@ namespace Dynatrace.OpenKit
         /// <summary>
         /// Sets the trust manager. Overrides the default trust manager which is <code>SSLStrictTrustManager</code>
         /// </summary>
+        /// <remarks>
+        /// The value is only set, if it is not <code>null</code>.
+        /// </remarks>
         /// <param name="trustManager">trust manager implementation</param>
         /// <returns><code>this</code></returns>
         public AbstractOpenKitBuilder WithTrustManager(ISSLTrustManager trustManager)
         {
-            this.trustManager = trustManager;
+            if (trustManager != null)
+            {
+                this.trustManager = trustManager;
+            }
             return this;
         }
 

--- a/src/openkit-shared/Core/Session.cs
+++ b/src/openkit-shared/Core/Session.cs
@@ -50,7 +50,7 @@ namespace Dynatrace.OpenKit.Core
             this.beacon = beacon;
 
             beaconSender.StartSession(this);
-            beacon.StartSession(this);
+            beacon.StartSession();
         }
 
         /// <summary>

--- a/src/openkit-shared/Protocol/Beacon.cs
+++ b/src/openkit-shared/Protocol/Beacon.cs
@@ -324,8 +324,7 @@ namespace Dynatrace.OpenKit.Protocol
         /// <summary>
         /// start the session
         /// </summary>
-        /// <param name="session"></param>
-        public void StartSession(Session session)
+        public void StartSession()
         {
             if (CapturingDisabled)
             {

--- a/src/openkit-shared/Protocol/Beacon.cs
+++ b/src/openkit-shared/Protocol/Beacon.cs
@@ -338,9 +338,9 @@ namespace Dynatrace.OpenKit.Protocol
 
             AddKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, 0);
             AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(session.EndTime));
+            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, 0L);
 
-            AddEventData(session.EndTime, eventBuilder);
+            AddEventData(sessionStartTime, eventBuilder);
         }
 
         /// <summary>

--- a/src/openkit-shared/Protocol/HTTPClientHttpClient.cs
+++ b/src/openkit-shared/Protocol/HTTPClientHttpClient.cs
@@ -25,9 +25,11 @@ namespace Dynatrace.OpenKit.Protocol
     public class HTTPClientHttpClient : HTTPClient
     {
 #if !WINDOWS_UWP
+#if NETSTANDARD2_0
         private static bool RemoteCertificateValidationCallbackInitialized = false;
+#endif // #if NETSTANDARD2_0
         private readonly System.Net.Security.RemoteCertificateValidationCallback remoteCertificateValidationCallback;
-#endif
+#endif // #if !WINDOWS_UWP
 
         public HTTPClientHttpClient(ILogger logger, HTTPClientConfiguration configuration) : base(logger, configuration)
         {

--- a/src/openkit-shared/Providers/DefaultHTTPClientProvider.cs
+++ b/src/openkit-shared/Providers/DefaultHTTPClientProvider.cs
@@ -32,7 +32,7 @@ namespace Dynatrace.OpenKit.Providers
         public IHTTPClient CreateClient(HTTPClientConfiguration configuration)
         {
 #if NET40 || NET35
-            return new HTTPClientWebClient(logger, configuration); // HttpClient is not availalbe in .NET 4.0
+            return new HTTPClientWebClient(logger, configuration); // HttpClient is not availalbe in .NET 3.5 and 4.0
 #else
             return new HTTPClientHttpClient(logger, configuration);
 #endif

--- a/tests/openkit-shared-tests/Core/Configuration/OpenKitConfigurationTest.cs
+++ b/tests/openkit-shared-tests/Core/Configuration/OpenKitConfigurationTest.cs
@@ -150,6 +150,18 @@ namespace Dynatrace.OpenKit.Core.Configuration
             Assert.That(crashReportingLevel, Is.EqualTo(CrashReportingLevel.OPT_IN_CRASHES));
         }
 
+        [Test]
+        public void ADefaultConstructedConfigurationUsesStrictTrustManager()
+        {
+            var target = CreateDefaultConfig();
+
+            //when retrieving SSL Trust manager
+            var sslTrustManager = target.HTTPClientConfig.SSLTrustManager;
+
+            // then
+            Assert.That(sslTrustManager, Is.InstanceOf<SSLStrictTrustManager>());
+        }
+
 
         private static OpenKitConfiguration CreateDefaultConfig()
         {

--- a/tests/openkit-shared-tests/OpenKitBuilderTest.cs
+++ b/tests/openkit-shared-tests/OpenKitBuilderTest.cs
@@ -75,6 +75,18 @@ namespace Dynatrace.OpenKit
         }
 
         [Test]
+        public void CannotSetNullTrustManagerForAppMon()
+        {
+            // when
+            var target = new AppMonOpenKitBuilder(Endpoint, AppName, DeviceID)
+                .WithTrustManager(null)
+                .BuildConfiguration();
+
+            // then
+            Assert.That(target.HTTPClientConfig.SSLTrustManager, Is.InstanceOf<SSLStrictTrustManager>());
+        }
+
+        [Test]
         public void CanOverrideTrustManagerForDynatrace()
         {
             // given 
@@ -87,6 +99,18 @@ namespace Dynatrace.OpenKit
 
             // then
             Assert.That(target.HTTPClientConfig.SSLTrustManager, Is.SameAs(trustManager));
+        }
+
+        [Test]
+        public void CannotSetNullTrustManagerForDynatrace()
+        {
+            // when
+            var target = new DynatraceOpenKitBuilder(Endpoint, AppID, DeviceID)
+                .WithTrustManager(null)
+                .BuildConfiguration();
+
+            // then
+            Assert.That(target.HTTPClientConfig.SSLTrustManager, Is.InstanceOf<SSLStrictTrustManager>());
         }
 
         [Test]


### PR DESCRIPTION
When reporting a session start event, `t0` must be set to `0` according to the protocol.