### PR TITLE
Overload for string deviceID

### DIFF
--- a/src/openkit-shared/AbstractOpenKitBuilder.cs
+++ b/src/openkit-shared/AbstractOpenKitBuilder.cs
@@ -41,7 +41,7 @@ namespace Dynatrace.OpenKit
         private CrashReportingLevel crashReportingLevel = BeaconConfiguration.DEFAULT_CRASH_REPORTING_LEVEL;
 
 
-        protected AbstractOpenKitBuilder(string endpointURL, long deviceID)
+        protected AbstractOpenKitBuilder(string endpointURL, string deviceID)
         {
             EndpointURL = endpointURL;
             DeviceID = deviceID;
@@ -54,7 +54,7 @@ namespace Dynatrace.OpenKit
         protected ISSLTrustManager TrustManager => trustManager;
         protected ILogger Logger => logger ?? new DefaultLogger(verbose);
         protected string EndpointURL { get; private set; }
-        protected long DeviceID { get; private set; }
+        protected string DeviceID { get; private set; }
         protected long BeaconCacheMaxBeaconAge => beaconCacheMaxBeaconAge;
         protected long BeaconCacheLowerMemoryBoundary => beaconCacheLowerMemoryBoundary;
         protected long BeaconCacheUpperMemoryBoundary => beaconCacheUpperMemoryBoundary;

--- a/src/openkit-shared/AbstractOpenKitBuilder.cs
+++ b/src/openkit-shared/AbstractOpenKitBuilder.cs
@@ -18,6 +18,7 @@ using Dynatrace.OpenKit.API;
 using Dynatrace.OpenKit.Core;
 using Dynatrace.OpenKit.Core.Configuration;
 using Dynatrace.OpenKit.Protocol.SSL;
+using System.Globalization;
 
 namespace Dynatrace.OpenKit
 {
@@ -40,6 +41,10 @@ namespace Dynatrace.OpenKit
         private DataCollectionLevel dataCollectionLevel = BeaconConfiguration.DEFAULT_DATA_COLLECTION_LEVEL;
         private CrashReportingLevel crashReportingLevel = BeaconConfiguration.DEFAULT_CRASH_REPORTING_LEVEL;
 
+        protected AbstractOpenKitBuilder(string endpointURL, long deviceID) :
+            this(endpointURL, deviceID.ToString(CultureInfo.InvariantCulture))
+        {
+        }
 
         protected AbstractOpenKitBuilder(string endpointURL, string deviceID)
         {

--- a/src/openkit-shared/AppMonOpenKitBuilder.cs
+++ b/src/openkit-shared/AppMonOpenKitBuilder.cs
@@ -17,6 +17,7 @@
 using Dynatrace.OpenKit.Core;
 using Dynatrace.OpenKit.Core.Configuration;
 using Dynatrace.OpenKit.Providers;
+using System.Globalization;
 
 namespace Dynatrace.OpenKit
 {
@@ -34,6 +35,17 @@ namespace Dynatrace.OpenKit
         /// <param name="applicationName">unique application id</param>
         /// <param name="deviceID">unique device id</param>
         public AppMonOpenKitBuilder(string endpointURL, string applicationName, long deviceID) 
+            : this(endpointURL, applicationName, deviceID.ToString(CultureInfo.InvariantCulture))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of type AppMonOpenKitBuilder
+        /// </summary>
+        /// <param name="endpointURL">endpoint OpenKit connects to</param>
+        /// <param name="applicationName">unique application id</param>
+        /// <param name="deviceID">unique device id</param>
+        public AppMonOpenKitBuilder(string endpointURL, string applicationName, string deviceID)
             : base(endpointURL, deviceID)
         {
             this.applicationName = applicationName;

--- a/src/openkit-shared/Core/Configuration/OpenKitConfiguration.cs
+++ b/src/openkit-shared/Core/Configuration/OpenKitConfiguration.cs
@@ -50,7 +50,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
         private readonly ISessionIDProvider sessionIDProvider;
 
         // *** constructors ***
-       public OpenKitConfiguration(OpenKitType openKitType, string applicationName, string applicationID, long deviceID, string endpointURL,
+       public OpenKitConfiguration(OpenKitType openKitType, string applicationName, string applicationID, string deviceID, string endpointURL,
             ISessionIDProvider sessionIDProvider, ISSLTrustManager trustManager, Device device, string applicationVersion,
             BeaconCacheConfiguration beaconCacheConfiguration, BeaconConfiguration beaconConfiguration)
         {
@@ -105,7 +105,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
 
         public string ApplicationID { get; }
 
-        public long DeviceID { get; }
+        public string DeviceID { get; }
 
         public string EndpointURL { get; }
 

--- a/src/openkit-shared/DynatraceOpenKitBuilder.cs
+++ b/src/openkit-shared/DynatraceOpenKitBuilder.cs
@@ -17,6 +17,7 @@
 using Dynatrace.OpenKit.Core;
 using Dynatrace.OpenKit.Core.Configuration;
 using Dynatrace.OpenKit.Providers;
+using System.Globalization;
 
 namespace Dynatrace.OpenKit
 {
@@ -35,6 +36,17 @@ namespace Dynatrace.OpenKit
         /// <param name="applicationID">unique application id</param>
         /// <param name="deviceID">unique device id</param>
         public DynatraceOpenKitBuilder(string endointURL, string applicationID, long deviceID)
+            : this(endointURL, applicationID, deviceID.ToString(CultureInfo.InvariantCulture))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of type DynatraceOpenKitBuilder
+        /// </summary>
+        /// <param name="endointURL">endpoint OpenKit connects to</param>
+        /// <param name="applicationID">unique application id</param>
+        /// <param name="deviceID">unique device id</param>
+        public DynatraceOpenKitBuilder(string endointURL, string applicationID, string deviceID)
             : base(endointURL, deviceID)
         {
             this.applicationID = applicationID;

--- a/src/openkit-shared/Protocol/Beacon.cs
+++ b/src/openkit-shared/Protocol/Beacon.cs
@@ -36,61 +36,61 @@ namespace Dynatrace.OpenKit.Protocol
     public class Beacon
     {
         // Initial time to sleep after the first failed beacon send attempt.
-        private const int INITIAL_RETRY_SLEEP_TIME_MILLISECONDS = 1000;
+        private const int InitialRetrySleepTimeMilliseconds = 1000;
 
 
         // basic data constants
-        private const string BEACON_KEY_PROTOCOL_VERSION = "vv";
-        private const string BEACON_KEY_OPENKIT_VERSION = "va";
-        private const string BEACON_KEY_APPLICATION_ID = "ap";
-        private const string BEACON_KEY_APPLICATION_NAME = "an";
-        private const string BEACON_KEY_APPLICATION_VERSION = "vn";
-        private const string BEACON_KEY_PLATFORM_TYPE = "pt";
-        private const string BEACON_KEY_AGENT_TECHNOLOGY_TYPE = "tt";
-        private const string BEACON_KEY_VISITOR_ID = "vi";
-        private const string BEACON_KEY_SESSION_NUMBER = "sn";
-        private const string BEACON_KEY_CLIENT_IP_ADDRESS = "ip";
-        private const string BEACON_KEY_MULTIPLICITY = "mp";
-        private const string BEACON_KEY_DATA_COLLECTION_LEVEL = "dl";
-        private const string BEACON_KEY_CRASH_REPORTING_LEVEL = "cl";
+        private const string BeaconKeyProtocolVersion = "vv";
+        private const string BeaconKeyOpenKitVersion = "va";
+        private const string BeaconKeyApplicationID = "ap";
+        private const string BeaconKeyApplicationName = "an";
+        private const string BeaconKeyApplicationVersion = "vn";
+        private const string BeaconKeyPlatformType = "pt";
+        private const string BeaconKeyAgentTechnologyType = "tt";
+        private const string BeaconKeyVisitorID = "vi";
+        private const string BeaconKeySessionNumber = "sn";
+        private const string BeaconKeyClientIPAddress = "ip";
+        private const string BeaconKeyMultiplicity = "mp";
+        private const string BeaconKeyDataCollectionLevel = "dl";
+        private const string BeaconKeyCrashReportingLevel = "cl";
 
         // device data constants
-        private const string BEACON_KEY_DEVICE_OS = "os";
-        private const string BEACON_KEY_DEVICE_MANUFACTURER = "mf";
-        private const string BEACON_KEY_DEVICE_MODEL = "md";
+        private const string BeaconKeyDeviceOS = "os";
+        private const string BeaconKeyDeviceManufacturer = "mf";
+        private const string BeaconKeyDeviceModel = "md";
 
         // timestamp constants
-        private const string BEACON_KEY_SESSION_START_TIME = "tv";
-        private const string BEACON_KEY_TIMESYNC_TIME = "ts";
-        private const string BEACON_KEY_TRANSMISSION_TIME = "tx";
+        private const string BeaconKeySessionStartTime = "tv";
+        private const string BeaconKeyTimeSyncTime = "ts";
+        private const string BeaconKeyTransmissionTime = "tx";
 
         // Action related constants
-        private const string BEACON_KEY_EVENT_TYPE = "et";
-        private const string BEACON_KEY_NAME = "na";
-        private const string BEACON_KEY_THREAD_ID = "it";
-        private const string BEACON_KEY_ACTION_ID = "ca";
-        private const string BEACON_KEY_PARENT_ACTION_ID = "pa";
-        private const string BEACON_KEY_START_SEQUENCE_NUMBER = "s0";
-        private const string BEACON_KEY_TIME_0 = "t0";
-        private const string BEACON_KEY_END_SEQUENCE_NUMBER = "s1";
-        private const string BEACON_KEY_TIME_1 = "t1";
+        private const string BeaconKeyEventType = "et";
+        private const string BeaconKeyName = "na";
+        private const string BeaconKeyThreadID = "it";
+        private const string BeaconKeyActionID = "ca";
+        private const string BeaconKeyParentActionID = "pa";
+        private const string BeaconKeyStartSequenceNumber = "s0";
+        private const string BeaconKeyTimeZero = "t0";
+        private const string BeaconKeyEndSequenceNumber = "s1";
+        private const string BeaconKeyTimeOne = "t1";
 
         // data and error capture constants
-        private const string BEACON_KEY_VALUE = "vl";
-        private const string BEACON_KEY_ERROR_CODE = "ev";
-        private const string BEACON_KEY_ERROR_REASON = "rs";
-        private const string BEACON_KEY_ERROR_STACKTRACE = "st";
-        private const string BEACON_KEY_WEBREQUEST_RESPONSECODE = "rc";
-        private const string BEACON_KEY_WEBREQUEST_BYTES_SEND = "bs";
-        private const string BEACON_KEY_WEBREQUEST_BYTES_RECEIVED = "br";
+        private const string BeaconKeyValue = "vl";
+        private const string BeaconKeyErrorCode = "ev";
+        private const string BeaconKeyErrorReason = "rs";
+        private const string BeaconKeyErrorStacktrace = "st";
+        private const string BeaconKeyWebrequstResponseCode = "rc";
+        private const string BeaconKeyWebrequestBytesSent = "bs";
+        private const string BeaconKeyWebrequestBytesReceived = "br";
 
         // max name length
-        internal const int MAX_NAME_LEN = 250;
+        internal const int MaximumNameLength = 250;
 
         // web request tag prefix constant
-        private const string TAG_PREFIX = "MT";
+        private const string WebRequestTagPrefix = "MT";
 
-        private const char BEACON_DATA_DELIMITER = '&';
+        private const char BeaconDataDelimiter = '&';
 
         // next ID and sequence number
         private int nextID = 0;
@@ -231,9 +231,10 @@ namespace Dynatrace.OpenKit.Protocol
 
         /// <summary>
         /// Returns an immutable list of the event data
-        /// 
-        /// Used for testing
         /// </summary>
+        /// <remarks>
+        /// Used for testing
+        /// </remarks>
         internal List<string> EventDataList
         {
             get
@@ -250,9 +251,10 @@ namespace Dynatrace.OpenKit.Protocol
 
         /// <summary>
         /// Returns an immutable list of the action data
-        /// 
-        /// Used for testing
         /// </summary>
+        /// <remarks>
+        /// Used for testing
+        /// </remarks>
         internal List<string> ActionDataList
         {
             get
@@ -282,7 +284,7 @@ namespace Dynatrace.OpenKit.Protocol
                 return string.Empty;
             }
 
-            return TAG_PREFIX + "_"
+            return WebRequestTagPrefix + "_"
                        + ProtocolConstants.PROTOCOL_VERSION + "_"
                        + httpConfiguration.ServerID + "_"
                        + DeviceID + "_"
@@ -313,12 +315,12 @@ namespace Dynatrace.OpenKit.Protocol
 
             BuildBasicEventData(actionBuilder, EventType.ACTION, action.Name);
 
-            AddKeyValuePair(actionBuilder, BEACON_KEY_ACTION_ID, action.ID);
-            AddKeyValuePair(actionBuilder, BEACON_KEY_PARENT_ACTION_ID, action.ParentID);
-            AddKeyValuePair(actionBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, action.StartSequenceNo);
-            AddKeyValuePair(actionBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(action.StartTime));
-            AddKeyValuePair(actionBuilder, BEACON_KEY_END_SEQUENCE_NUMBER, action.EndSequenceNo);
-            AddKeyValuePair(actionBuilder, BEACON_KEY_TIME_1, action.EndTime - action.StartTime);
+            AddKeyValuePair(actionBuilder, BeaconKeyActionID, action.ID);
+            AddKeyValuePair(actionBuilder, BeaconKeyParentActionID, action.ParentID);
+            AddKeyValuePair(actionBuilder, BeaconKeyStartSequenceNumber, action.StartSequenceNo);
+            AddKeyValuePair(actionBuilder, BeaconKeyTimeZero, GetTimeSinceBeaconCreation(action.StartTime));
+            AddKeyValuePair(actionBuilder, BeaconKeyEndSequenceNumber, action.EndSequenceNo);
+            AddKeyValuePair(actionBuilder, BeaconKeyTimeOne, action.EndTime - action.StartTime);
 
             AddActionData(action.StartTime, actionBuilder);
         }
@@ -337,9 +339,9 @@ namespace Dynatrace.OpenKit.Protocol
 
             BuildBasicEventData(eventBuilder, EventType.SESSION_START, null);
 
-            AddKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, 0);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, 0L);
+            AddKeyValuePair(eventBuilder, BeaconKeyParentActionID, 0);
+            AddKeyValuePair(eventBuilder, BeaconKeyStartSequenceNumber, NextSequenceNumber);
+            AddKeyValuePair(eventBuilder, BeaconKeyTimeZero, 0L);
 
             AddEventData(sessionStartTime, eventBuilder);
         }
@@ -364,9 +366,9 @@ namespace Dynatrace.OpenKit.Protocol
 
             BuildBasicEventData(eventBuilder, EventType.SESSION_END, null);
 
-            AddKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, 0);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(session.EndTime));
+            AddKeyValuePair(eventBuilder, BeaconKeyParentActionID, 0);
+            AddKeyValuePair(eventBuilder, BeaconKeyStartSequenceNumber, NextSequenceNumber);
+            AddKeyValuePair(eventBuilder, BeaconKeyTimeZero, GetTimeSinceBeaconCreation(session.EndTime));
 
             AddEventData(session.EndTime, eventBuilder);
         }
@@ -393,7 +395,7 @@ namespace Dynatrace.OpenKit.Protocol
             StringBuilder eventBuilder = new StringBuilder();
 
             var eventTimestamp = BuildEvent(eventBuilder, EventType.VALUE_INT, valueName, parentAction);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_VALUE, value);
+            AddKeyValuePair(eventBuilder, BeaconKeyValue, value);
 
             AddEventData(eventTimestamp, eventBuilder);
         }
@@ -419,7 +421,7 @@ namespace Dynatrace.OpenKit.Protocol
             StringBuilder eventBuilder = new StringBuilder();
 
             var eventTimestamp = BuildEvent(eventBuilder, EventType.VALUE_DOUBLE, valueName, parentAction);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_VALUE, value);
+            AddKeyValuePair(eventBuilder, BeaconKeyValue, value);
 
             AddEventData(eventTimestamp, eventBuilder);
         }
@@ -445,7 +447,7 @@ namespace Dynatrace.OpenKit.Protocol
             StringBuilder eventBuilder = new StringBuilder();
 
             var eventTimestamp = BuildEvent(eventBuilder, EventType.VALUE_STRING, valueName, parentAction);
-            AddKeyValuePairIfValueIsNotNull(eventBuilder, BEACON_KEY_VALUE, TruncateNullSafe(value));
+            AddKeyValuePairIfValueIsNotNull(eventBuilder, BeaconKeyValue, TruncateNullSafe(value));
 
             AddEventData(eventTimestamp, eventBuilder);
         }
@@ -499,11 +501,11 @@ namespace Dynatrace.OpenKit.Protocol
             BuildBasicEventData(eventBuilder, EventType.ERROR, errorName);
 
             var timestamp = timingProvider.ProvideTimestampInMilliseconds();
-            AddKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, parentAction.ID);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(timestamp));
-            AddKeyValuePair(eventBuilder, BEACON_KEY_ERROR_CODE, errorCode);
-            AddKeyValuePairIfValueIsNotNull(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
+            AddKeyValuePair(eventBuilder, BeaconKeyParentActionID, parentAction.ID);
+            AddKeyValuePair(eventBuilder, BeaconKeyStartSequenceNumber, NextSequenceNumber);
+            AddKeyValuePair(eventBuilder, BeaconKeyTimeZero, GetTimeSinceBeaconCreation(timestamp));
+            AddKeyValuePair(eventBuilder, BeaconKeyErrorCode, errorCode);
+            AddKeyValuePairIfValueIsNotNull(eventBuilder, BeaconKeyErrorReason, reason);
 
             AddEventData(timestamp, eventBuilder);
         }
@@ -532,11 +534,11 @@ namespace Dynatrace.OpenKit.Protocol
             BuildBasicEventData(eventBuilder, EventType.CRASH, errorName);
 
             var timestamp = timingProvider.ProvideTimestampInMilliseconds();
-            AddKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, 0);                                  // no parent action
-            AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(timestamp));
-            AddKeyValuePairIfValueIsNotNull(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
-            AddKeyValuePairIfValueIsNotNull(eventBuilder, BEACON_KEY_ERROR_STACKTRACE, stacktrace);
+            AddKeyValuePair(eventBuilder, BeaconKeyParentActionID, 0);                                  // no parent action
+            AddKeyValuePair(eventBuilder, BeaconKeyStartSequenceNumber, NextSequenceNumber);
+            AddKeyValuePair(eventBuilder, BeaconKeyTimeZero, GetTimeSinceBeaconCreation(timestamp));
+            AddKeyValuePairIfValueIsNotNull(eventBuilder, BeaconKeyErrorReason, reason);
+            AddKeyValuePairIfValueIsNotNull(eventBuilder, BeaconKeyErrorStacktrace, stacktrace);
 
             AddEventData(timestamp, eventBuilder);
         }
@@ -562,22 +564,22 @@ namespace Dynatrace.OpenKit.Protocol
 
             BuildBasicEventData(eventBuilder, EventType.WEBREQUEST, webRequestTracer.URL);
 
-            AddKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, parentAction.ID);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, webRequestTracer.StartSequenceNo);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(webRequestTracer.StartTime));
-            AddKeyValuePair(eventBuilder, BEACON_KEY_END_SEQUENCE_NUMBER, webRequestTracer.EndSequenceNo);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_1, webRequestTracer.EndTime - webRequestTracer.StartTime);
+            AddKeyValuePair(eventBuilder, BeaconKeyParentActionID, parentAction.ID);
+            AddKeyValuePair(eventBuilder, BeaconKeyStartSequenceNumber, webRequestTracer.StartSequenceNo);
+            AddKeyValuePair(eventBuilder, BeaconKeyTimeZero, GetTimeSinceBeaconCreation(webRequestTracer.StartTime));
+            AddKeyValuePair(eventBuilder, BeaconKeyEndSequenceNumber, webRequestTracer.EndSequenceNo);
+            AddKeyValuePair(eventBuilder, BeaconKeyTimeOne, webRequestTracer.EndTime - webRequestTracer.StartTime);
             if (webRequestTracer.ResponseCode != -1)
             {
-                AddKeyValuePair(eventBuilder, BEACON_KEY_WEBREQUEST_RESPONSECODE, webRequestTracer.ResponseCode);
+                AddKeyValuePair(eventBuilder, BeaconKeyWebrequstResponseCode, webRequestTracer.ResponseCode);
             }
             if (webRequestTracer.BytesSent > -1)
             {
-                AddKeyValuePair(eventBuilder, BEACON_KEY_WEBREQUEST_BYTES_SEND, webRequestTracer.BytesSent);
+                AddKeyValuePair(eventBuilder, BeaconKeyWebrequestBytesSent, webRequestTracer.BytesSent);
             }
             if (webRequestTracer.BytesReceived > -1)
             {
-                AddKeyValuePair(eventBuilder, BEACON_KEY_WEBREQUEST_BYTES_RECEIVED, webRequestTracer.BytesReceived);
+                AddKeyValuePair(eventBuilder, BeaconKeyWebrequestBytesReceived, webRequestTracer.BytesReceived);
             }
 
             AddEventData(webRequestTracer.StartTime, eventBuilder);
@@ -604,9 +606,9 @@ namespace Dynatrace.OpenKit.Protocol
             BuildBasicEventData(eventBuilder, EventType.IDENTIFY_USER, userTag);
 
             var timestamp = timingProvider.ProvideTimestampInMilliseconds();
-            AddKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, 0);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
-            AddKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(timestamp));
+            AddKeyValuePair(eventBuilder, BeaconKeyParentActionID, 0);
+            AddKeyValuePair(eventBuilder, BeaconKeyStartSequenceNumber, NextSequenceNumber);
+            AddKeyValuePair(eventBuilder, BeaconKeyTimeZero, GetTimeSinceBeaconCreation(timestamp));
 
             AddEventData(timestamp, eventBuilder);
         }
@@ -625,11 +627,11 @@ namespace Dynatrace.OpenKit.Protocol
             while (true)
             {
                 // prefix for this chunk - must be built up newly, due to changing timestamps
-                var prefix = basicBeaconData + BEACON_DATA_DELIMITER + CreateTimestampData();
+                var prefix = basicBeaconData + BeaconDataDelimiter + CreateTimestampData();
                 // subtract 1024 to ensure that the chunk does not exceed the send size configured on server side?
                 // i guess that was the original intention, but i'm not sure about this
                 // TODO stefan.eberl - This is a quite uncool algorithm and should be improved, avoid subtracting some "magic" number
-                var chunk = beaconCache.GetNextBeaconChunk(SessionNumber, prefix, configuration.MaxBeaconSize - 1024, BEACON_DATA_DELIMITER);
+                var chunk = beaconCache.GetNextBeaconChunk(SessionNumber, prefix, configuration.MaxBeaconSize - 1024, BeaconDataDelimiter);
                 if (string.IsNullOrEmpty(chunk))
                 {
                     // no data added so far or no data to send
@@ -696,7 +698,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             StatusResponse response = null;
             var retry = 0;
-            var retrySleepMillis = INITIAL_RETRY_SLEEP_TIME_MILLISECONDS;
+            var retrySleepMillis = InitialRetrySleepTimeMilliseconds;
 
             while (true)
             {
@@ -731,9 +733,9 @@ namespace Dynatrace.OpenKit.Protocol
 
             var eventTimestamp = timingProvider.ProvideTimestampInMilliseconds();
 
-            AddKeyValuePair(builder, BEACON_KEY_PARENT_ACTION_ID, parentAction.ID);
-            AddKeyValuePair(builder, BEACON_KEY_START_SEQUENCE_NUMBER, NextSequenceNumber);
-            AddKeyValuePair(builder, BEACON_KEY_TIME_0, GetTimeSinceBeaconCreation(eventTimestamp));
+            AddKeyValuePair(builder, BeaconKeyParentActionID, parentAction.ID);
+            AddKeyValuePair(builder, BeaconKeyStartSequenceNumber, NextSequenceNumber);
+            AddKeyValuePair(builder, BeaconKeyTimeZero, GetTimeSinceBeaconCreation(eventTimestamp));
 
             return eventTimestamp;
         }
@@ -741,9 +743,9 @@ namespace Dynatrace.OpenKit.Protocol
         // helper method for building basic event data
         private void BuildBasicEventData(StringBuilder builder, EventType eventType, string name)
         {
-            AddKeyValuePair(builder, BEACON_KEY_EVENT_TYPE, (int)eventType);
-            AddKeyValuePairIfValueIsNotNull(builder, BEACON_KEY_NAME, TruncateNullSafe(name));
-            AddKeyValuePair(builder, BEACON_KEY_THREAD_ID, threadIDProvider.ThreadID);
+            AddKeyValuePair(builder, BeaconKeyEventType, (int)eventType);
+            AddKeyValuePairIfValueIsNotNull(builder, BeaconKeyName, TruncateNullSafe(name));
+            AddKeyValuePair(builder, BeaconKeyThreadID, threadIDProvider.ThreadID);
         }
        
 
@@ -753,26 +755,26 @@ namespace Dynatrace.OpenKit.Protocol
             StringBuilder basicBeaconBuilder = new StringBuilder();
 
             // version and application information
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_PROTOCOL_VERSION, ProtocolConstants.PROTOCOL_VERSION);
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_OPENKIT_VERSION, ProtocolConstants.OPENKIT_VERSION);
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_APPLICATION_ID, configuration.ApplicationID);
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_APPLICATION_NAME, configuration.ApplicationName);
-            AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BEACON_KEY_APPLICATION_VERSION, configuration.ApplicationVersion);
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_PLATFORM_TYPE, ProtocolConstants.PLATFORM_TYPE_OPENKIT);
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_AGENT_TECHNOLOGY_TYPE, ProtocolConstants.AGENT_TECHNOLOGY_TYPE);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyProtocolVersion, ProtocolConstants.PROTOCOL_VERSION);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyOpenKitVersion, ProtocolConstants.OPENKIT_VERSION);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyApplicationID, configuration.ApplicationID);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyApplicationName, configuration.ApplicationName);
+            AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BeaconKeyApplicationVersion, configuration.ApplicationVersion);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyPlatformType, ProtocolConstants.PLATFORM_TYPE_OPENKIT);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyAgentTechnologyType, ProtocolConstants.AGENT_TECHNOLOGY_TYPE);
 
             // device/visitor ID, session number and IP address
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_VISITOR_ID, DeviceID);
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_SESSION_NUMBER, SessionNumber);
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_CLIENT_IP_ADDRESS, clientIPAddress);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyVisitorID, DeviceID);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeySessionNumber, SessionNumber);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyClientIPAddress, clientIPAddress);
 
             // platform information
-            AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BEACON_KEY_DEVICE_OS, configuration.Device.OperatingSystem);
-            AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BEACON_KEY_DEVICE_MANUFACTURER, configuration.Device.Manufacturer);
-            AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BEACON_KEY_DEVICE_MODEL, configuration.Device.ModelID);
+            AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BeaconKeyDeviceOS, configuration.Device.OperatingSystem);
+            AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BeaconKeyDeviceManufacturer, configuration.Device.Manufacturer);
+            AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BeaconKeyDeviceModel, configuration.Device.ModelID);
 
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_DATA_COLLECTION_LEVEL, (int)beaconConfiguration.DataCollectionLevel);
-            AddKeyValuePair(basicBeaconBuilder, BEACON_KEY_CRASH_REPORTING_LEVEL, (int)beaconConfiguration.CrashReportingLevel);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyDataCollectionLevel, (int)beaconConfiguration.DataCollectionLevel);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyCrashReportingLevel, (int)beaconConfiguration.CrashReportingLevel);
 
             return basicBeaconBuilder.ToString();
         }
@@ -782,11 +784,11 @@ namespace Dynatrace.OpenKit.Protocol
         {
             StringBuilder timestampBuilder = new StringBuilder();
 
-            AddKeyValuePair(timestampBuilder, BEACON_KEY_SESSION_START_TIME, timingProvider.ConvertToClusterTime(sessionStartTime));
-            AddKeyValuePair(timestampBuilder, BEACON_KEY_TIMESYNC_TIME, timingProvider.ConvertToClusterTime(sessionStartTime));
+            AddKeyValuePair(timestampBuilder, BeaconKeySessionStartTime, timingProvider.ConvertToClusterTime(sessionStartTime));
+            AddKeyValuePair(timestampBuilder, BeaconKeyTimeSyncTime, timingProvider.ConvertToClusterTime(sessionStartTime));
             if (!timingProvider.IsTimeSyncSupported)
             {
-                AddKeyValuePair(timestampBuilder, BEACON_KEY_TRANSMISSION_TIME, timingProvider.ProvideTimestampInMilliseconds());
+                AddKeyValuePair(timestampBuilder, BeaconKeyTransmissionTime, timingProvider.ProvideTimestampInMilliseconds());
             }
 
             return timestampBuilder.ToString();
@@ -855,9 +857,9 @@ namespace Dynatrace.OpenKit.Protocol
         private static string Truncate(string name)
         {
             name = name.Trim();
-            if (name.Length > MAX_NAME_LEN)
+            if (name.Length > MaximumNameLength)
             {
-                name = name.Substring(0, MAX_NAME_LEN);
+                name = name.Substring(0, MaximumNameLength);
             }
             return name;
         }

--- a/src/openkit-shared/Protocol/Beacon.cs
+++ b/src/openkit-shared/Protocol/Beacon.cs
@@ -165,7 +165,8 @@ namespace Dynatrace.OpenKit.Protocol
             else
             {
                 SessionNumber = 1;
-                DeviceID = randomNumberGenerator.NextLong(long.MaxValue).ToString(CultureInfo.InvariantCulture);
+                DeviceID = randomNumberGenerator.NextLong(long.MaxValue)
+                    .ToString(CultureInfo.InvariantCulture);
             }
 
             this.timingProvider = timingProvider;

--- a/src/openkit-shared/Protocol/Beacon.cs
+++ b/src/openkit-shared/Protocol/Beacon.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Linq;
+using System.Globalization;
 
 namespace Dynatrace.OpenKit.Protocol
 {
@@ -84,7 +85,7 @@ namespace Dynatrace.OpenKit.Protocol
         private const string BEACON_KEY_WEBREQUEST_BYTES_RECEIVED = "br";
 
         // max name length
-        private const int MAX_NAME_LEN = 250;
+        internal const int MAX_NAME_LEN = 250;
 
         // web request tag prefix constant
         private const string TAG_PREFIX = "MT";
@@ -159,12 +160,12 @@ namespace Dynatrace.OpenKit.Protocol
             if (beaconConfiguration.DataCollectionLevel == DataCollectionLevel.USER_BEHAVIOR)
             {
                 SessionNumber = configuration.NextSessionNumber;
-                DeviceID = configuration.DeviceID;
+                DeviceID = Truncate(configuration.DeviceID);
             }
             else
             {
                 SessionNumber = 1;
-                DeviceID = randomNumberGenerator.NextLong(long.MaxValue);
+                DeviceID = randomNumberGenerator.NextLong(long.MaxValue).ToString(CultureInfo.InvariantCulture);
             }
 
             this.timingProvider = timingProvider;
@@ -189,7 +190,7 @@ namespace Dynatrace.OpenKit.Protocol
         // *** public properties ***
         public int SessionNumber { get; }
 
-        public long DeviceID { get; }
+        public string DeviceID { get; }
 
         public bool IsEmpty => beaconCache.IsEmpty(SessionNumber);
 

--- a/tests/openkit-shared-tests/Core/Configuration/OpenKitConfigurationTest.cs
+++ b/tests/openkit-shared-tests/Core/Configuration/OpenKitConfigurationTest.cs
@@ -182,7 +182,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
 
             var defaultBeaconConfig = new BeaconConfiguration();
 
-            return new OpenKitConfiguration(OpenKitType.DYNATRACE, "", "", 0, "", new Providers.TestSessionIDProvider(),
+            return new OpenKitConfiguration(OpenKitType.DYNATRACE, "", "", "0", "", new Providers.TestSessionIDProvider(),
                   new SSLStrictTrustManager(), new Core.Device("", "", ""), "", defaultCacheConfig, defaultBeaconConfig);
         }
     }

--- a/tests/openkit-shared-tests/Core/WebRequestTracerBaseTest.cs
+++ b/tests/openkit-shared-tests/Core/WebRequestTracerBaseTest.cs
@@ -39,7 +39,7 @@ namespace Dynatrace.OpenKit.Core
             logger = Substitute.For<ILogger>();
             mockTimingProvider = Substitute.For<ITimingProvider>();
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OPT_IN_CRASHES);
-            testConfiguration = new TestConfiguration(1, beaconConfig);
+            testConfiguration = new TestConfiguration("1", beaconConfig);
             beacon = new Beacon(logger,
                                 new BeaconCache(logger),
                                 testConfiguration,

--- a/tests/openkit-shared-tests/OpenKitBuilderTest.cs
+++ b/tests/openkit-shared-tests/OpenKitBuilderTest.cs
@@ -21,13 +21,53 @@ namespace Dynatrace.OpenKit
         [Test]
         public void DefaultsAreSetForAppMon()
         {
-            VerifyDefaultsAreSet(new AppMonOpenKitBuilder(Endpoint, AppID, DeviceID).BuildConfiguration());
+            // when
+            var obtained = new AppMonOpenKitBuilder(Endpoint, AppName, DeviceID).BuildConfiguration();
+
+            // then
+            Assert.That(obtained.EndpointURL, Is.EqualTo(Endpoint));
+            Assert.That(obtained.DeviceID, Is.EqualTo("1234"));
+            Assert.That(obtained.ApplicationName, Is.EqualTo(AppName));
+            Assert.That(obtained.ApplicationID, Is.EqualTo(AppName));
+            
+            // ensure remaining defaults
+            VerifyDefaultsAreSet(obtained);
+        }
+
+        [Test]
+        public void AppMonOpenKitBuilderTakesStringDeviceID()
+        {
+            // given
+            var target = new AppMonOpenKitBuilder(Endpoint, AppName, "stringDeviceID");
+
+            // when, then
+            Assert.That(target.BuildConfiguration().DeviceID, Is.EqualTo("stringDeviceID"));
         }
 
         [Test]
         public void DefaultsAreSetForDynatrace()
         {
-            VerifyDefaultsAreSet(new DynatraceOpenKitBuilder(Endpoint, AppName, DeviceID).BuildConfiguration());
+            // when
+            var obtained = new DynatraceOpenKitBuilder(Endpoint, AppID, DeviceID).BuildConfiguration();
+
+            // then
+            Assert.That(obtained.EndpointURL, Is.EqualTo(Endpoint));
+            Assert.That(obtained.DeviceID, Is.EqualTo("1234"));
+            Assert.That(obtained.ApplicationName, Is.EqualTo(string.Empty));
+            Assert.That(obtained.ApplicationID, Is.EqualTo(AppID));
+
+            // ensure remaining defaults
+            VerifyDefaultsAreSet(obtained);
+        }
+
+        [Test]
+        public void DynatraceOpenKitBuilderTakesStringDeviceID()
+        {
+            // given
+            var target = new DynatraceOpenKitBuilder(Endpoint, AppID, "stringDeviceID");
+
+            // when, then
+            Assert.That(target.BuildConfiguration().DeviceID, Is.EqualTo("stringDeviceID"));
         }
 
         private void VerifyDefaultsAreSet(OpenKitConfiguration configuration)
@@ -431,7 +471,7 @@ namespace Dynatrace.OpenKit
 
         private class TestOpenKitBuilder : AbstractOpenKitBuilder
         {
-            internal TestOpenKitBuilder() : base("", 0)
+            internal TestOpenKitBuilder() : base("", "0")
             {
             }
 

--- a/tests/openkit-shared-tests/Protocol/BeaconTest.cs
+++ b/tests/openkit-shared-tests/Protocol/BeaconTest.cs
@@ -22,6 +22,8 @@ using Dynatrace.OpenKit.API;
 using Dynatrace.OpenKit.Core.Caching;
 using Dynatrace.OpenKit.Core.Communication;
 using Dynatrace.OpenKit.Core.Configuration;
+using System.Linq;
+using System.Text;
 
 namespace Dynatrace.OpenKit.Protocol
 {
@@ -299,7 +301,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var session = new Session(logger, beaconSender, target); // will 
@@ -316,7 +318,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var action = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -333,7 +335,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var intValue = 42;
@@ -351,7 +353,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var doubleValue = System.Math.E;
@@ -369,7 +371,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var stringValue = "Write once, debug everywhere";
@@ -387,7 +389,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -404,7 +406,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -421,7 +423,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             // when
@@ -436,7 +438,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -454,7 +456,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             // when
@@ -470,7 +472,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -491,7 +493,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -512,7 +514,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -533,7 +535,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -550,7 +552,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
 
@@ -566,7 +568,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
@@ -579,11 +581,11 @@ namespace Dynatrace.OpenKit.Protocol
         }
 
         [Test]
-        public void VisitorIDIsRandomizedOnDataCollectionLevel0()
+        public void DeviceIDIsRandomizedOnDataCollectionLevel0()
         {
             // given
             var beaconConfig = new BeaconConfiguration(12345, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(0, beaconConfig);
+            var config = new TestConfiguration("0", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
@@ -594,11 +596,11 @@ namespace Dynatrace.OpenKit.Protocol
         }
 
         [Test]
-        public void VisitorIDIsRandomizedOnDataCollectionLevel1()
+        public void DeviceIDIsRandomizedOnDataCollectionLevel1()
         {
             // given
             var beaconConfig = new BeaconConfiguration(12345, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
@@ -609,52 +611,74 @@ namespace Dynatrace.OpenKit.Protocol
         }
 
         [Test]
-        public void GivenVisitorIDIsUsedOnDataCollectionLevel2()
+        public void GivenDeviceIDIsUsedOnDataCollectionLevel2()
         {
-            var DEVICE_ID = 12345;
+            var deviceID = "12345";
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(DEVICE_ID, beaconConfig);
+            var config = new TestConfiguration(deviceID, beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
-            var visitorID = target.DeviceID;
+            var obtained = target.DeviceID;
 
             //then
             randomGenerator.Received(0).NextLong(long.MaxValue);
-            Assert.That(visitorID, Is.EqualTo(DEVICE_ID));
+            Assert.That(obtained, Is.EqualTo(deviceID));
         }
 
         [Test]
-        public void RandomVisitorIDCannotBeNegativeOnDataCollectionLevel0()
+        public void RandomDeviceIDCannotBeNegativeOnDataCollectionLevel0()
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
-            var visitorID = target.DeviceID;
+            var deviceID = long.Parse(target.DeviceID);
 
             //then
-            Assert.That(visitorID, Is.GreaterThanOrEqualTo(0));
-            Assert.That(visitorID, Is.LessThanOrEqualTo(long.MaxValue));
+            Assert.That(deviceID, Is.GreaterThanOrEqualTo(0L));
+            Assert.That(deviceID, Is.LessThanOrEqualTo(long.MaxValue));
         }
 
         [Test]
-        public void RandomVisitorIDCannotBeNegativeOnDataCollectionLevel1()
+        public void RandomDeviceIDCannotBeNegativeOnDataCollectionLevel1()
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
-            var visitorID = target.DeviceID;
+            var deviceID = long.Parse(target.DeviceID);
 
             //then
-            Assert.That(visitorID, Is.GreaterThanOrEqualTo(0));
-            Assert.That(visitorID, Is.LessThanOrEqualTo(long.MaxValue));
+            Assert.That(deviceID, Is.GreaterThanOrEqualTo(0L));
+            Assert.That(deviceID, Is.LessThanOrEqualTo(long.MaxValue));
+        }
+
+        [Test]
+        public void DeviceIDIsTruncatedTo250Characters()
+        {
+            // given
+            var deviceIDBuilder = new StringBuilder();
+            for (var i = 0; i < Beacon.MAX_NAME_LEN - 1; i++)
+            {
+                deviceIDBuilder.Append("a");
+            }
+            deviceIDBuilder.Append("bc");
+            var deviceID = deviceIDBuilder.ToString();
+            var config = new TestConfiguration(deviceID, beaconConfig);
+            var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
+
+            // when
+            var obtained = target.DeviceID;
+            
+            // then
+            Assert.That(obtained.Length, Is.EqualTo(Beacon.MAX_NAME_LEN));
+            Assert.That(obtained, Is.EqualTo(deviceID.Substring(0, Beacon.MAX_NAME_LEN)));
         }
 
         [Test]
@@ -662,7 +686,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
@@ -677,7 +701,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
@@ -693,7 +717,7 @@ namespace Dynatrace.OpenKit.Protocol
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
             var sessionIDProvider = Substitute.For<ISessionIDProvider>();
-            var config = new TestConfiguration(1, beaconConfig, sessionIDProvider);
+            var config = new TestConfiguration("1", beaconConfig, sessionIDProvider);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
@@ -710,7 +734,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
@@ -727,7 +751,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
@@ -745,7 +769,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -761,7 +785,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var session = new Session(logger, beaconSender, target);
 
@@ -777,7 +801,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var session = new Session(logger, beaconSender, target);
 
@@ -794,7 +818,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             var session = new Session(logger, beaconSender, target);
@@ -811,7 +835,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
@@ -826,7 +850,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
@@ -841,7 +865,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
             //when
@@ -856,7 +880,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "test action", new SynchronizedQueue<IAction>());
 
@@ -872,7 +896,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "test action", new SynchronizedQueue<IAction>());
 
@@ -888,7 +912,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "test action", new SynchronizedQueue<IAction>());
 
@@ -904,7 +928,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "test action", new SynchronizedQueue<IAction>());
 
@@ -920,7 +944,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OPT_OUT_CRASHES);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "test action", new SynchronizedQueue<IAction>());
 
@@ -936,7 +960,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OPT_IN_CRASHES);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "test action", new SynchronizedQueue<IAction>());
 
@@ -952,7 +976,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -968,7 +992,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -985,7 +1009,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1002,7 +1026,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1018,7 +1042,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1035,7 +1059,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1052,7 +1076,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1068,7 +1092,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1085,7 +1109,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1102,7 +1126,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1118,7 +1142,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1134,7 +1158,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
 
@@ -1164,7 +1188,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var session = new Session(logger, beaconSender, target);
 
@@ -1181,7 +1205,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var session = new Session(logger, beaconSender, target);
 
@@ -1198,7 +1222,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var session = new Session(logger, beaconSender, target);
 
@@ -1214,7 +1238,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OPT_IN_CRASHES);
-            var config = new TestConfiguration(1, beaconConfig);
+            var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
             var session = new Session(logger, beaconSender, target);
 

--- a/tests/openkit-shared-tests/Protocol/BeaconTest.cs
+++ b/tests/openkit-shared-tests/Protocol/BeaconTest.cs
@@ -663,7 +663,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var deviceIDBuilder = new StringBuilder();
-            for (var i = 0; i < Beacon.MaxNameLength - 1; i++)
+            for (var i = 0; i < Beacon.MaximumNameLength - 1; i++)
             {
                 deviceIDBuilder.Append("a");
             }
@@ -676,8 +676,8 @@ namespace Dynatrace.OpenKit.Protocol
             var obtained = target.DeviceID;
             
             // then
-            Assert.That(obtained.Length, Is.EqualTo(Beacon.MaxNameLength));
-            Assert.That(obtained, Is.EqualTo(deviceID.Substring(0, Beacon.MaxNameLength)));
+            Assert.That(obtained.Length, Is.EqualTo(Beacon.MaximumNameLength));
+            Assert.That(obtained, Is.EqualTo(deviceID.Substring(0, Beacon.MaximumNameLength)));
         }
 
         [Test]

--- a/tests/openkit-shared-tests/Protocol/BeaconTest.cs
+++ b/tests/openkit-shared-tests/Protocol/BeaconTest.cs
@@ -22,7 +22,6 @@ using Dynatrace.OpenKit.API;
 using Dynatrace.OpenKit.Core.Caching;
 using Dynatrace.OpenKit.Core.Communication;
 using Dynatrace.OpenKit.Core.Configuration;
-using System.Linq;
 using System.Text;
 
 namespace Dynatrace.OpenKit.Protocol

--- a/tests/openkit-shared-tests/Protocol/BeaconTest.cs
+++ b/tests/openkit-shared-tests/Protocol/BeaconTest.cs
@@ -663,7 +663,7 @@ namespace Dynatrace.OpenKit.Protocol
         {
             // given
             var deviceIDBuilder = new StringBuilder();
-            for (var i = 0; i < Beacon.MAX_NAME_LEN - 1; i++)
+            for (var i = 0; i < Beacon.MaxNameLength - 1; i++)
             {
                 deviceIDBuilder.Append("a");
             }
@@ -676,8 +676,8 @@ namespace Dynatrace.OpenKit.Protocol
             var obtained = target.DeviceID;
             
             // then
-            Assert.That(obtained.Length, Is.EqualTo(Beacon.MAX_NAME_LEN));
-            Assert.That(obtained, Is.EqualTo(deviceID.Substring(0, Beacon.MAX_NAME_LEN)));
+            Assert.That(obtained.Length, Is.EqualTo(Beacon.MaxNameLength));
+            Assert.That(obtained, Is.EqualTo(deviceID.Substring(0, Beacon.MaxNameLength)));
         }
 
         [Test]

--- a/tests/openkit-shared-tests/TestConfiguration.cs
+++ b/tests/openkit-shared-tests/TestConfiguration.cs
@@ -23,17 +23,17 @@ namespace Dynatrace.OpenKit
     public class TestConfiguration : OpenKitConfiguration
     {
         public TestConfiguration()
-            : this( 0, new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OPT_IN_CRASHES), new Providers.TestSessionIDProvider())
+            : this("0", new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OPT_IN_CRASHES), new Providers.TestSessionIDProvider())
         {
         }
 
-        internal TestConfiguration(int deviceID, BeaconConfiguration beaconConfig)
+        internal TestConfiguration(string deviceID, BeaconConfiguration beaconConfig)
             : this(deviceID, beaconConfig, new Providers.DefaultSessionIDProvider() )
         {
 
         }
 
-        internal TestConfiguration(int deviceID, BeaconConfiguration beaconConfig, ISessionIDProvider sessionIDProvider)
+        internal TestConfiguration(string deviceID, BeaconConfiguration beaconConfig, ISessionIDProvider sessionIDProvider)
             : base(OpenKitType.DYNATRACE, "", "", deviceID, "", sessionIDProvider, 
                   new SSLStrictTrustManager(), new Core.Device("", "", ""), "", 
                   new BeaconCacheConfiguration(


### PR DESCRIPTION
This has the advantage that deviceIDs are no longer restricted
to be longs. It is possible to pass a 250 character long deviceID,
which can be a UUID or something similar.