### PR TITLE
Implement standalone web request tagging

### DIFF
--- a/src/openkit-shared/API/IAction.cs
+++ b/src/openkit-shared/API/IAction.cs
@@ -87,7 +87,7 @@ namespace Dynatrace.OpenKit.API
 
         /// <summary>
         ///  Allows tracing and timing of a web request handled by any 3rd party HTTP Client (e.g. Apache, Google, ...).
-        ///  In this case the Dynatrace HTTP header (OpenKitFactory.WEBREQUEST_TAG_HEADER) has to be set manually to the
+        ///  In this case the Dynatrace HTTP header (<see cref="OpenKitConstants.WEBREQUEST_TAG_HEADER"/>) has to be set manually to the
         ///  traces value of this WebRequestTracer.
         ///  If the web request is continued on a server-side Agent (e.g. Java, .NET, ...) this Session will be correlated to
         ///  the resulting server-side PurePath.

--- a/src/openkit-shared/API/ISession.cs
+++ b/src/openkit-shared/API/ISession.cs
@@ -55,6 +55,21 @@ namespace Dynatrace.OpenKit.API
         void ReportCrash(string errorName, string reason, string stacktrace);
 
         /// <summary>
+        ///  Allows tracing and timing of a web request handled by any 3rd party HTTP Client (e.g. Apache, Google, ...).
+        ///  In this case the Dynatrace HTTP header (<see cref="OpenKitConstants.WEBREQUEST_TAG_HEADER"/>) has to be set manually to the
+        ///  traces value of this WebRequestTracer.
+        ///  If the web request is continued on a server-side Agent (e.g. Java, .NET, ...) this Session will be correlated to
+        ///  the resulting server-side PurePath.
+        /// </summary>
+        /// <remarks>
+        /// If given <paramref name="url"/> is <code>null</code> or an empty string, then
+        /// a <see cref="NullWebRequestTracer"/> is returned and nothing is reported to the server.
+        /// </remarks>
+        /// <param name="url">the URL of the web request to be traced and timed</param>
+        /// <returns>a WebRequestTracer which allows getting the tag value and adding timing information</returns>
+        IWebRequestTracer TraceWebRequest(string url);
+
+        /// <summary>
         ///  Ends this Session and marks it as ready for immediate sending.
         /// </summary>
         void End();

--- a/src/openkit-shared/Core/Action.cs
+++ b/src/openkit-shared/Core/Action.cs
@@ -192,7 +192,7 @@ namespace Dynatrace.OpenKit.Core
             }
             if (!IsActionLeft)
             {
-                return new WebRequestTracerStringURL(logger, beacon, this, url);
+                return new WebRequestTracerStringURL(logger, beacon, ID, url);
             }
 
             return NullWebRequestTracer;

--- a/src/openkit-shared/Core/NullSession.cs
+++ b/src/openkit-shared/Core/NullSession.cs
@@ -21,6 +21,7 @@ namespace Dynatrace.OpenKit.Core
     public class NullSession : ISession
     {
         private static readonly IRootAction NullRootAction = new NullRootAction();
+        private static readonly IWebRequestTracer NullWebRequestTracer = new NullWebRequestTracer();
 
         public void Dispose()
         {
@@ -45,6 +46,11 @@ namespace Dynatrace.OpenKit.Core
         public void ReportCrash(string errorName, string reason, string stacktrace)
         {
             // intentionally left empty, due to NullObject pattern
+        }
+
+        public IWebRequestTracer TraceWebRequest(string url)
+        {
+            return NullWebRequestTracer;
         }
     }
 }

--- a/src/openkit-shared/Core/Session.cs
+++ b/src/openkit-shared/Core/Session.cs
@@ -29,6 +29,7 @@ namespace Dynatrace.OpenKit.Core
     public class Session : ISession
     {
         private static readonly NullRootAction NullRootAction = new NullRootAction();
+        private static readonly NullWebRequestTracer NullWebRequestTracer = new NullWebRequestTracer();
 
         private readonly ILogger logger;
 
@@ -128,6 +129,30 @@ namespace Dynatrace.OpenKit.Core
             {
                 beacon.ReportCrash(errorName, reason, stacktrace);
             }
+        }
+
+        public IWebRequestTracer TraceWebRequest(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                logger.Warn($"{this}TraceWebRequest (String): url must not be null or empty");
+                return NullWebRequestTracer;
+            }
+            if (!WebRequestTracerStringURL.IsValidURLScheme(url))
+            {
+                logger.Warn($"{this}TraceWebRequest (String): url \"{url}\" does not have a valid scheme");
+                return NullWebRequestTracer;
+            }
+            if (logger.IsDebugEnabled)
+            {
+                logger.Debug($"{this}TraceWebRequest (String) ({url})");
+            }
+            if (!IsSessionEnded)
+            {
+                return new WebRequestTracerStringURL(logger, beacon, 0, url);
+            }
+
+            return NullWebRequestTracer;
         }
 
         public void End()

--- a/src/openkit-shared/Core/WebRequestTracerStringURL.cs
+++ b/src/openkit-shared/Core/WebRequestTracerStringURL.cs
@@ -32,7 +32,7 @@ namespace Dynatrace.OpenKit.Core
 
         // *** constructors ***
 
-        public WebRequestTracerStringURL(ILogger logger, Beacon beacon, Action action, string url) : base(logger, beacon, action)
+        public WebRequestTracerStringURL(ILogger logger, Beacon beacon, int parentActionID, string url) : base(logger, beacon, parentActionID)
         {
             // separate query string from URL
             if (IsValidURLScheme(url))

--- a/src/openkit-shared/Protocol/Beacon.cs
+++ b/src/openkit-shared/Protocol/Beacon.cs
@@ -274,25 +274,25 @@ namespace Dynatrace.OpenKit.Protocol
         /// <summary>
         /// create web request tag
         /// </summary>
-        /// <param name="parentAction"></param>
+        /// <param name="parentActionID"></param>
         /// <param name="sequenceNo"></param>
         /// <returns></returns>
-        public string CreateTag(Action parentAction, int sequenceNo)
+        public string CreateTag(int parentActionID, int sequenceNo)
         {
             if (BeaconConfiguration.DataCollectionLevel == DataCollectionLevel.OFF)
             {
                 return string.Empty;
             }
 
-            return WebRequestTagPrefix + "_"
-                       + ProtocolConstants.PROTOCOL_VERSION + "_"
-                       + httpConfiguration.ServerID + "_"
-                       + DeviceID + "_"
-                       + SessionNumber + "_"
-                       + configuration.ApplicationID + "_"
-                       + parentAction.ID + "_"
-                       + threadIDProvider.ThreadID + "_"
-                       + sequenceNo;
+            return $"{WebRequestTagPrefix}_"
+                + $"{ProtocolConstants.PROTOCOL_VERSION}_"
+                + $"{httpConfiguration.ServerID}_"
+                + $"{DeviceID}_"
+                + $"{SessionNumber}_"
+                + $"{configuration.ApplicationID}_"
+                + $"{parentActionID}_"
+                + $"{threadIDProvider.ThreadID}_"
+                + $"{sequenceNo}";
         }
 
         /// <summary>
@@ -546,9 +546,9 @@ namespace Dynatrace.OpenKit.Protocol
         /// <summary>
         /// add web request to the provided Action
         /// </summary>
-        /// <param name="parentAction"></param>
+        /// <param name="parentActionID"></param>
         /// <param name="webRequestTracer"></param>
-        public void AddWebRequest(Action parentAction, WebRequestTracerBase webRequestTracer)
+        public void AddWebRequest(int parentActionID, WebRequestTracerBase webRequestTracer)
         {
             if (CapturingDisabled)
             {
@@ -564,7 +564,7 @@ namespace Dynatrace.OpenKit.Protocol
 
             BuildBasicEventData(eventBuilder, EventType.WEBREQUEST, webRequestTracer.URL);
 
-            AddKeyValuePair(eventBuilder, BeaconKeyParentActionID, parentAction.ID);
+            AddKeyValuePair(eventBuilder, BeaconKeyParentActionID, parentActionID);
             AddKeyValuePair(eventBuilder, BeaconKeyStartSequenceNumber, webRequestTracer.StartSequenceNo);
             AddKeyValuePair(eventBuilder, BeaconKeyTimeZero, GetTimeSinceBeaconCreation(webRequestTracer.StartTime));
             AddKeyValuePair(eventBuilder, BeaconKeyEndSequenceNumber, webRequestTracer.EndSequenceNo);

--- a/tests/openkit-shared-tests/Core/WebRequestTracerBaseTest.cs
+++ b/tests/openkit-shared-tests/Core/WebRequestTracerBaseTest.cs
@@ -28,7 +28,6 @@ namespace Dynatrace.OpenKit.Core
     public class WebRequestTracerBaseTest
     {
         private Beacon beacon;
-        private Action action;
         private ILogger logger;
         private OpenKitConfiguration testConfiguration;
         private ITimingProvider mockTimingProvider;
@@ -46,21 +45,20 @@ namespace Dynatrace.OpenKit.Core
                                 "127.0.0.1",
                                 Substitute.For<IThreadIDProvider>(),
                                 mockTimingProvider);
-            action = new RootAction(logger, beacon, "ActionName", new SynchronizedQueue<IAction>());
         }
 
         [Test]
         public void DefaultValues()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
 
             // then
             Assert.That(target.URL, Is.EqualTo("<unknown>"));
             Assert.That(target.ResponseCode, Is.EqualTo(-1));
             Assert.That(target.StartTime, Is.EqualTo(0L));
             Assert.That(target.EndTime, Is.EqualTo(-1L));
-            Assert.That(target.StartSequenceNo, Is.EqualTo(2));
+            Assert.That(target.StartSequenceNo, Is.EqualTo(1));
             Assert.That(target.EndSequenceNo, Is.EqualTo(-1));
             Assert.That(target.BytesSent, Is.EqualTo(-1));
             Assert.That(target.BytesReceived, Is.EqualTo(-1));
@@ -70,10 +68,10 @@ namespace Dynatrace.OpenKit.Core
         public void GetTag()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
 
             // then
-            var expectedTag = beacon.CreateTag(action, 2);
+            var expectedTag = beacon.CreateTag(17, 1);
             Assert.That(target.Tag, Is.EqualTo(expectedTag));
         }
 
@@ -81,7 +79,7 @@ namespace Dynatrace.OpenKit.Core
         public void ANewlyCreatedWebRequestTracerIsNotStopped()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
 
             // then
             Assert.That(target.IsStopped, Is.False);
@@ -91,7 +89,7 @@ namespace Dynatrace.OpenKit.Core
         public void AWebRequestTracerIsStoppedAfterStopHasBeenCalled()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
 
             // when calling the stop method
             target.Stop();
@@ -104,7 +102,7 @@ namespace Dynatrace.OpenKit.Core
         public void DisposingAWebRequestTracerStopsIt()
         {
             // given
-            IDisposable target = new TestWebRequestTracerBase(logger, beacon, action);
+            IDisposable target = new TestWebRequestTracerBase(logger, beacon, 17);
 
             // when disposing the target
             target.Dispose();
@@ -117,7 +115,7 @@ namespace Dynatrace.OpenKit.Core
         public void SetResponseCodeSetsTheResponseCode()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
 
             // when setting response code
             var obtained = target.SetResponseCode(418);
@@ -131,7 +129,7 @@ namespace Dynatrace.OpenKit.Core
         public void SetResponseCodeDoesNotSetTheResponseCodeIfStopped()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
             target.Stop();
 
             // when setting response code
@@ -147,7 +145,7 @@ namespace Dynatrace.OpenKit.Core
         public void SetBytesSentSetsTheNumberOfSentBytes()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
 
             // when setting the sent bytes
             var obtained = target.SetBytesSent(1234);
@@ -161,7 +159,7 @@ namespace Dynatrace.OpenKit.Core
         public void SetBytesSentDoesNotSetAnythingIfStopped()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
             target.Stop();
 
             // when setting the sent bytes
@@ -176,7 +174,7 @@ namespace Dynatrace.OpenKit.Core
         public void SetBytesReceivedSetsTheNumberOfReceivedBytes()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
 
             // when setting the received bytes
             var obtained = target.SetBytesReceived(4321);
@@ -190,7 +188,7 @@ namespace Dynatrace.OpenKit.Core
         public void SetBytesReceivedDoesNotSetAnythingIfStopped()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
             target.Stop();
 
             // when setting the received bytes
@@ -205,7 +203,7 @@ namespace Dynatrace.OpenKit.Core
         public void StartSetsTheStartTime()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
             mockTimingProvider.ProvideTimestampInMilliseconds().Returns(123456789L);
 
             // when starting web request tracing
@@ -220,7 +218,7 @@ namespace Dynatrace.OpenKit.Core
         public void StartDoesNothingIfAlreadyStopped()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
             mockTimingProvider.ProvideTimestampInMilliseconds().Returns(123456789L);
             target.Stop();
 
@@ -236,7 +234,7 @@ namespace Dynatrace.OpenKit.Core
         public void StopCanOnlyBeExecutedOnce()
         {
             // given
-            var target = new TestWebRequestTracerBase(logger, beacon, action);
+            var target = new TestWebRequestTracerBase(logger, beacon, 17);
             mockTimingProvider.ProvideTimestampInMilliseconds().Returns(123L, 321L);
 
             // when executed the first time
@@ -244,7 +242,7 @@ namespace Dynatrace.OpenKit.Core
             target.Stop();
 
             // then
-            Assert.That(target.EndSequenceNo, Is.EqualTo(3));
+            Assert.That(target.EndSequenceNo, Is.EqualTo(2));
             Assert.That(target.EndTime, Is.EqualTo(123L));
             Assert.That(beacon.IsEmpty, Is.False);
 
@@ -253,14 +251,14 @@ namespace Dynatrace.OpenKit.Core
             target.Stop();
 
             // then
-            Assert.That(target.EndSequenceNo, Is.EqualTo(3));
+            Assert.That(target.EndSequenceNo, Is.EqualTo(2));
             Assert.That(target.EndTime, Is.EqualTo(123L));
             Assert.That(beacon.IsEmpty, Is.True);
         }
 
         private sealed class TestWebRequestTracerBase : WebRequestTracerBase
         {
-            public TestWebRequestTracerBase(ILogger logger, Beacon beacon, Action action) : base(logger, beacon, action)
+            public TestWebRequestTracerBase(ILogger logger, Beacon beacon, int parentActionID) : base(logger, beacon, parentActionID)
             {
             }
         }

--- a/tests/openkit-shared-tests/Core/WebRequestTracerStringURLTest.cs
+++ b/tests/openkit-shared-tests/Core/WebRequestTracerStringURLTest.cs
@@ -91,7 +91,7 @@ namespace Dynatrace.OpenKit.Core
         public void AnURLIsOnlySetInConstructorIfItIsValid()
         {
             // given
-            var target = new WebRequestTracerStringURL(logger, beacon, action, "a1337://foo");
+            var target = new WebRequestTracerStringURL(logger, beacon, 21, "a1337://foo");
 
             // then
             Assert.That(target.URL, Is.EqualTo("a1337://foo"));
@@ -101,7 +101,7 @@ namespace Dynatrace.OpenKit.Core
         public void IfURLIsInvalidTheDefaultValueIsUsed()
         {
             // given
-            var target = new WebRequestTracerStringURL(logger, beacon, action, "foobar");
+            var target = new WebRequestTracerStringURL(logger, beacon, 42, "foobar");
 
             // then
             Assert.That(target.URL, Is.EqualTo("<unknown>"));

--- a/tests/openkit-shared-tests/Protocol/BeaconTest.cs
+++ b/tests/openkit-shared-tests/Protocol/BeaconTest.cs
@@ -95,17 +95,16 @@ namespace Dynatrace.OpenKit.Protocol
             {
                 BeaconConfiguration = beaconConfig
             };
-
-            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "https://127.0.0.1";
-            var webRequest = new WebRequestTracerStringURL(logger, target, action, testURL);
+            
+            const string testURL = "https://127.0.0.1";
+            var webRequest = new WebRequestTracerStringURL(logger, target, 1, testURL);
             var bytesSent = 123;
 
             //when
             webRequest.Start().SetBytesSent(bytesSent).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs={bytesSent}" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=1&t0=0&s1=2&t1=0&bs={bytesSent}" }));
         }
 
         [Test]
@@ -116,17 +115,16 @@ namespace Dynatrace.OpenKit.Protocol
             {
                 BeaconConfiguration = beaconConfig
             };
-
-            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "https://127.0.0.1";
-            var webRequest = new WebRequestTracerStringURL(logger, target, action, testURL);
+            
+            const string testURL = "https://127.0.0.1";
+            var webRequest = new WebRequestTracerStringURL(logger, target, 1, testURL);
             var bytesSent = 0;
 
             //when
             webRequest.Start().SetBytesSent(bytesSent).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs={bytesSent}" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=1&t0=0&s1=2&t1=0&bs={bytesSent}" }));
         }
 
         [Test]
@@ -137,16 +135,15 @@ namespace Dynatrace.OpenKit.Protocol
             {
                 BeaconConfiguration = beaconConfig
             };
-
-            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "https://127.0.0.1";
-            var webRequest = new WebRequestTracerStringURL(logger, target, action, testURL);
+            
+            const string testURL = "https://127.0.0.1";
+            var webRequest = new WebRequestTracerStringURL(logger, target, 1, testURL);
 
             //when
             webRequest.Start().SetBytesSent(-1).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=1&t0=0&s1=2&t1=0" }));
         }
 
         [Test]
@@ -157,17 +154,16 @@ namespace Dynatrace.OpenKit.Protocol
             {
                 BeaconConfiguration = beaconConfig
             };
-
-            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "https://127.0.0.1";
-            var webRequest = new WebRequestTracerStringURL(logger, target, action, testURL);
+            
+            const string testURL = "https://127.0.0.1";
+            var webRequest = new WebRequestTracerStringURL(logger, target, 1, testURL);
             var bytesReceived = 12321;
 
             //when
             webRequest.Start().SetBytesReceived(bytesReceived).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&br={bytesReceived}" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=1&t0=0&s1=2&t1=0&br={bytesReceived}" }));
         }
 
         [Test]
@@ -178,17 +174,16 @@ namespace Dynatrace.OpenKit.Protocol
             {
                 BeaconConfiguration = beaconConfig
             };
-
-            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "https://127.0.0.1";
-            var webRequest = new WebRequestTracerStringURL(logger, target, action, testURL);
+            
+            const string testURL = "https://127.0.0.1";
+            var webRequest = new WebRequestTracerStringURL(logger, target, 1, testURL);
             var bytesReceived = 0;
 
             //when
             webRequest.Start().SetBytesReceived(bytesReceived).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&br={bytesReceived}" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=1&t0=0&s1=2&t1=0&br={bytesReceived}" }));
         }
 
         [Test]
@@ -199,16 +194,15 @@ namespace Dynatrace.OpenKit.Protocol
             {
                 BeaconConfiguration = beaconConfig
             };
-
-            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "https://127.0.0.1";
-            var webRequest = new WebRequestTracerStringURL(logger, target, action, testURL);
+            
+            const string testURL = "https://127.0.0.1";
+            var webRequest = new WebRequestTracerStringURL(logger, target, 1, testURL);
 
             //when
             webRequest.Start().SetBytesReceived(-1).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=1&t0=0&s1=2&t1=0" }));
         }
 
         [Test]
@@ -220,9 +214,8 @@ namespace Dynatrace.OpenKit.Protocol
                 BeaconConfiguration = beaconConfig
             };
 
-            var action = new Action(logger, target, "TestRootAction", new SynchronizedQueue<IAction>());
-            var testURL = "https://127.0.0.1";
-            var webRequest = new WebRequestTracerStringURL(logger, target, action, testURL);
+            const string testURL = "https://127.0.0.1";
+            var webRequest = new WebRequestTracerStringURL(logger, target, 1, testURL);
             var bytesReceived = 12321;
             var bytesSent = 123;
 
@@ -230,7 +223,7 @@ namespace Dynatrace.OpenKit.Protocol
             webRequest.Start().SetBytesSent(bytesSent).SetBytesReceived(bytesReceived).Stop(); //stop will add the web request to the beacon
 
             //then
-            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=2&t0=0&s1=3&t1=0&bs=123&br=12321" }));
+            Assert.That(target.EventDataList, Is.EquivalentTo(new[] { $"et=30&na={System.Uri.EscapeDataString(testURL)}&it=0&pa=1&s0=1&t0=0&s1=2&t1=0&bs=123&br=12321" }));
         }
 
         [Test]
@@ -439,12 +432,11 @@ namespace Dynatrace.OpenKit.Protocol
             var beaconConfig = new BeaconConfiguration(0, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
             var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
-
-            var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
-            var webRequestTracer = new WebRequestTracerStringURL(logger, target, parentAction, "https://foo.bar");
+            
+            var webRequestTracer = new WebRequestTracerStringURL(logger, target, 17, "https://foo.bar");
 
             // when
-            target.AddWebRequest(parentAction, webRequestTracer);
+            target.AddWebRequest(17, webRequestTracer);
 
             // then ensure nothing has been serialized
             Assert.That(target.IsEmpty, Is.True);
@@ -473,12 +465,11 @@ namespace Dynatrace.OpenKit.Protocol
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OFF);
             var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
-
-            var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
-            var webRequestTracer = Substitute.For<WebRequestTracerBase>(logger, target, parentAction);
+            
+            var webRequestTracer = Substitute.For<WebRequestTracerBase>(logger, target, 17);
 
             //when
-            target.AddWebRequest(parentAction, webRequestTracer);
+            target.AddWebRequest(17, webRequestTracer);
             var temp = webRequestTracer.Received(0).BytesReceived;
             temp = webRequestTracer.Received(0).BytesSent;
             temp = webRequestTracer.Received(0).ResponseCode;
@@ -494,12 +485,12 @@ namespace Dynatrace.OpenKit.Protocol
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
             var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
-
-            var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
-            var webRequestTracer = Substitute.For<WebRequestTracerBase>(logger, target, parentAction);
+            
+            var webRequestTracer = Substitute.For<WebRequestTracerBase>(logger, target, 17);
 
             //when
-            target.AddWebRequest(parentAction, webRequestTracer);
+            target.AddWebRequest(17, webRequestTracer);
+
             var temp = webRequestTracer.Received(1).BytesReceived;
             temp = webRequestTracer.Received(1).BytesSent;
             temp = webRequestTracer.Received(1).ResponseCode;
@@ -515,12 +506,12 @@ namespace Dynatrace.OpenKit.Protocol
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OFF);
             var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
-
-            var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
-            var webRequestTracer = Substitute.For<WebRequestTracerBase>(logger, target, parentAction);
+            
+            var webRequestTracer = Substitute.For<WebRequestTracerBase>(logger, target, 17);
 
             //when
-            target.AddWebRequest(parentAction, webRequestTracer);
+            target.AddWebRequest(17, webRequestTracer);
+
             var temp = webRequestTracer.Received(1).BytesReceived;
             temp = webRequestTracer.Received(1).BytesSent;
             temp = webRequestTracer.Received(1).ResponseCode;
@@ -537,13 +528,11 @@ namespace Dynatrace.OpenKit.Protocol
             var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
-            var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
-
             //when
-            var tagReturned = target.CreateTag(parentAction, 1);
+            var tagReturned = target.CreateTag(42, 1);
 
             //then
-            Assert.That(tagReturned.Length, Is.EqualTo(0));
+            Assert.That(tagReturned, Is.Empty);
         }
 
         [Test]
@@ -553,13 +542,12 @@ namespace Dynatrace.OpenKit.Protocol
             var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OFF);
             var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
-            var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
 
             //when
-            var tagReturned = target.CreateTag(parentAction, 1);
+            var obtained = target.CreateTag(42, 1);
 
             //then
-            Assert.That(tagReturned.Length, Is.GreaterThan(0));
+            Assert.That(obtained, Is.Not.Empty);
         }
 
         [Test]
@@ -570,13 +558,11 @@ namespace Dynatrace.OpenKit.Protocol
             var config = new TestConfiguration("1", beaconConfig);
             var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
 
-            var parentAction = new Action(logger, target, "ActionName", new SynchronizedQueue<IAction>());
-
             //when
-            var tagReturned = target.CreateTag(parentAction, 1);
+            var obtained = target.CreateTag(42, 1);
 
             //then
-            Assert.That(tagReturned.Length, Is.GreaterThan(0));
+            Assert.That(obtained, Is.Not.Empty);
         }
 
         [Test]


### PR DESCRIPTION
This is handled similar to the way it's done in Java.
On a session it is possible to obtain a WebRequestTracer.