### PR TITLE
URL Encode ApplicationID/DeviceID

### DIFF
--- a/src/openkit-shared/Core/Configuration/OpenKitConfiguration.cs
+++ b/src/openkit-shared/Core/Configuration/OpenKitConfiguration.cs
@@ -15,8 +15,10 @@
 //
 
 using Dynatrace.OpenKit.API;
+using Dynatrace.OpenKit.Core.Util;
 using Dynatrace.OpenKit.Protocol;
 using Dynatrace.OpenKit.Providers;
+using System.Text;
 
 namespace Dynatrace.OpenKit.Core.Configuration
 {
@@ -59,6 +61,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
             // immutable settings
             ApplicationName = applicationName;
             ApplicationID = applicationID;
+            ApplicationIDPercentEncoded = PercentEncoder.Encode(applicationID, Encoding.UTF8, new []{ '_' });
             DeviceID = deviceID;
             EndpointURL = endpointURL;
 
@@ -104,6 +107,8 @@ namespace Dynatrace.OpenKit.Core.Configuration
         public string ApplicationName { get; }
 
         public string ApplicationID { get; }
+
+        public string ApplicationIDPercentEncoded { get; }
 
         public string DeviceID { get; }
 

--- a/src/openkit-shared/Core/Util/PercentEncoder.cs
+++ b/src/openkit-shared/Core/Util/PercentEncoder.cs
@@ -1,0 +1,140 @@
+﻿//
+// Copyright 2018 Dynatrace LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using Dynatrace.OpenKit.Util;
+using System.Collections;
+using System.Linq;
+using System.Text;
+
+namespace Dynatrace.OpenKit.Core.Util
+{
+    /// <summary>
+    /// Utility class for percent-encoding (also known as URL encoding) strings.
+    /// </summary>
+    /// <remarks>
+    /// This class shall be used to percent escape (URL encode) strings.
+    /// 
+    /// Reserved characters are based on RFC 3986 (<seealso cref="https://tools.ietf.org/html/rfc3986#section-2.3"/>)
+    /// </remarks>
+    public static class PercentEncoder
+    {
+        private const int UNRESERVED_CHARACTERS_BITS = 128;
+        private static readonly BitArray UNRESERVED_CHARACTERS = new BitArray(UNRESERVED_CHARACTERS_BITS);
+
+        /// <summary>
+        /// Static constructor used to initialize <code>UNRESERVED_CHARACTERS_BITS</code>
+        /// </summary>
+        static PercentEncoder()
+        {
+            // 26 lower case letters, starting with 'a'
+            Enumerable.Range('a', 26).ForEach(c => UNRESERVED_CHARACTERS[c] = true);
+            // 26 upper case letters, starting with 'A'
+            Enumerable.Range('A', 26).ForEach(c => UNRESERVED_CHARACTERS[c] = true);
+            // 10 digits, starting with '0'
+            Enumerable.Range('0', 10).ForEach(c => UNRESERVED_CHARACTERS[c] = true);
+            // special characters based on RFC
+            UNRESERVED_CHARACTERS['-'] = true;
+            UNRESERVED_CHARACTERS['.'] = true;
+            UNRESERVED_CHARACTERS['_'] = true;
+            UNRESERVED_CHARACTERS['~'] = true;
+        }
+
+        /// <summary>
+        /// Percent-encode a given input string.
+        /// </summary>
+        /// <param name="input">The input string to percent-encode.</param>
+        /// <param name="encoding">Encoding used to encode characters.</param>
+        /// <param name="additionalReservedChars">Unreserved characters based on RFC 3986, but need to be encoded as well</param>
+        /// <returns>Percent encoded string.</returns>
+        public static string Encode(string input, Encoding encoding, char[] additionalReservedChars = default(char[]))
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+            
+            var unreservedCharacters = BuildUnreservedCharacters(additionalReservedChars);
+            var resultBuilder = new StringBuilder(input.Length);
+
+            var index = 0;
+            while (index < input.Length)
+            {
+                var c = input[index];
+                if (IsUnreservedCharacter(c, unreservedCharacters))
+                {
+                    // unreserved character, which does not need to be percent encoded
+                    resultBuilder.Append(c);
+                    index++;
+                }
+                else
+                {
+                    // reserved character, but encoding needs to be applied first
+                    StringBuilder sb = new StringBuilder().Append(c);
+                    index++;
+                    while (index < input.Length && !IsUnreservedCharacter(input[index], unreservedCharacters))
+                    {
+                        sb.Append(input[index]);
+                        index++;
+                    }
+                    // encode temp string using given encoding & percent encoding
+                    try
+                    {
+                        var encoded = encoding.GetBytes(sb.ToString());
+                        encoded.ForEach(encodedByte => resultBuilder.AppendFormat("%{0:X2}", encodedByte));
+                    }
+                    catch (EncoderFallbackException)
+                    {
+                        // should not be reached
+                        return null;
+                    }
+                }
+            }
+
+            return resultBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Build unreserved characters.
+        /// </summary>
+        /// <param name="additionalReservedChars">Additional characters to consider as reserved.</param>
+        /// <returns>Bitset where all reserved characters are set.</returns>
+        private static BitArray BuildUnreservedCharacters(char[] additionalReservedChars)
+        {
+            var unreservedCharacters = UNRESERVED_CHARACTERS;
+            if (additionalReservedChars != null && additionalReservedChars.Length > 0)
+            {
+                // duplicate unreserved characters
+                unreservedCharacters = new BitArray(UNRESERVED_CHARACTERS);
+                additionalReservedChars
+                    .Where(c => c < unreservedCharacters.Length)
+                    .ForEach(c => unreservedCharacters[c] = false);
+            }
+
+            return unreservedCharacters;
+        }
+
+        /// <summary>
+        /// Test if the given character <code>c</code> is unreserved.
+        /// </summary>
+        /// <param name="c">The character to test, whether it's unreserved or not.</param>
+        /// <param name="unreservedCharacters">Unreserved characters</param>
+        /// <returns><code>true</code> if it is an unreserved character, <code>false</code> otherwise.</returns>
+        private static bool IsUnreservedCharacter(char c, BitArray unreservedCharacters)
+        {
+            return c < unreservedCharacters.Length && unreservedCharacters[c];
+        }
+    }
+}

--- a/src/openkit-shared/Protocol/Beacon.cs
+++ b/src/openkit-shared/Protocol/Beacon.cs
@@ -90,6 +90,9 @@ namespace Dynatrace.OpenKit.Protocol
         // web request tag prefix constant
         private const string WebRequestTagPrefix = "MT";
 
+        // web request tag reserved characters
+        private static readonly char[] ReservedCharacters = { '_' };
+
         private const char BeaconDataDelimiter = '&';
 
         // next ID and sequence number
@@ -285,11 +288,11 @@ namespace Dynatrace.OpenKit.Protocol
             }
 
             return $"{WebRequestTagPrefix}_"
-                + $"{ProtocolConstants.PROTOCOL_VERSION}_"
+                + $"{ProtocolConstants.ProtocolVersion}_"
                 + $"{httpConfiguration.ServerID}_"
-                + $"{DeviceID}_"
+                + $"{PercentEncoder.Encode(DeviceID, Encoding.UTF8, ReservedCharacters)}_"
                 + $"{SessionNumber}_"
-                + $"{configuration.ApplicationID}_"
+                + $"{configuration.ApplicationIDPercentEncoded}_"
                 + $"{parentActionID}_"
                 + $"{threadIDProvider.ThreadID}_"
                 + $"{sequenceNo}";
@@ -755,13 +758,13 @@ namespace Dynatrace.OpenKit.Protocol
             StringBuilder basicBeaconBuilder = new StringBuilder();
 
             // version and application information
-            AddKeyValuePair(basicBeaconBuilder, BeaconKeyProtocolVersion, ProtocolConstants.PROTOCOL_VERSION);
-            AddKeyValuePair(basicBeaconBuilder, BeaconKeyOpenKitVersion, ProtocolConstants.OPENKIT_VERSION);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyProtocolVersion, ProtocolConstants.ProtocolVersion);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyOpenKitVersion, ProtocolConstants.OpenKitVersion);
             AddKeyValuePair(basicBeaconBuilder, BeaconKeyApplicationID, configuration.ApplicationID);
             AddKeyValuePair(basicBeaconBuilder, BeaconKeyApplicationName, configuration.ApplicationName);
             AddKeyValuePairIfValueIsNotNull(basicBeaconBuilder, BeaconKeyApplicationVersion, configuration.ApplicationVersion);
-            AddKeyValuePair(basicBeaconBuilder, BeaconKeyPlatformType, ProtocolConstants.PLATFORM_TYPE_OPENKIT);
-            AddKeyValuePair(basicBeaconBuilder, BeaconKeyAgentTechnologyType, ProtocolConstants.AGENT_TECHNOLOGY_TYPE);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyPlatformType, ProtocolConstants.PlatformTypeOpenKit);
+            AddKeyValuePair(basicBeaconBuilder, BeaconKeyAgentTechnologyType, ProtocolConstants.AgentTechnologyType);
 
             // device/visitor ID, session number and IP address
             AddKeyValuePair(basicBeaconBuilder, BeaconKeyVisitorID, DeviceID);
@@ -798,7 +801,7 @@ namespace Dynatrace.OpenKit.Protocol
         private static void AddKeyValuePair(StringBuilder builder, string key, string stringValue)
         {
             AppendKey(builder, key);
-            builder.Append(System.Uri.EscapeDataString(stringValue));
+            builder.Append(PercentEncoder.Encode(stringValue, Encoding.UTF8, ReservedCharacters));
         }
 
         private static void AddKeyValuePairIfValueIsNotNull(StringBuilder builder, string key, string stringValue)

--- a/src/openkit-shared/Protocol/HTTPClient.cs
+++ b/src/openkit-shared/Protocol/HTTPClient.cs
@@ -16,7 +16,7 @@
 
 using Dynatrace.OpenKit.API;
 using Dynatrace.OpenKit.Core.Configuration;
-
+using Dynatrace.OpenKit.Core.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -39,10 +39,10 @@ namespace Dynatrace.OpenKit.Protocol
         public class RequestType
         {
 
-            public static readonly RequestType STATUS = new RequestType("Status");              // status check
-            public static readonly RequestType BEACON = new RequestType("Beacon");              // beacon send
-            public static readonly RequestType TIMESYNC = new RequestType("TimeSync");          // time sync
-            public static readonly RequestType NEW_SESSION = new RequestType("NewSession");     // new session
+            public static readonly RequestType Status = new RequestType("Status");              // status check
+            public static readonly RequestType Beacon = new RequestType("Beacon");              // beacon send
+            public static readonly RequestType TimeSync = new RequestType("TimeSync");          // time sync
+            public static readonly RequestType NewSession = new RequestType("NewSession");     // new session
 
             public string RequestName { get; }
 
@@ -60,19 +60,22 @@ namespace Dynatrace.OpenKit.Protocol
         }
 
         // request type constants
-        internal const string REQUEST_TYPE_MOBILE = "type=m";
-        internal const string REQUEST_TYPE_TIMESYNC = "type=mts";
+        internal const string RequestTypeMobile = "type=m";
+        internal const string RequestTypeTimeSync = "type=mts";
 
         // query parameter constants
-        internal const string QUERY_KEY_SERVER_ID = "srvid";
-        internal const string QUERY_KEY_APPLICATION = "app";
-        internal const string QUERY_KEY_VERSION = "va";
-        internal const string QUERY_KEY_PLATFORM_TYPE = "pt";
-        internal const string QUERY_KEY_AGENT_TECHNOLOGY_TYPE = "tt";
+        internal const string QueryKeyServerId = "srvid";
+        internal const string QueryKeyApplication = "app";
+        internal const string QueryKeyVersion = "va";
+        internal const string QueryKeyPlatformType = "pt";
+        internal const string QueryKeyAgentTechnologyType = "tt";
+
+        // additional reserved characters for URL encoding
+        private static readonly char[] QueryReservedCharacters = { '_' };
 
         // connection constants
-        internal const int MAX_SEND_RETRIES = 3;
-        private const int RETRY_SLEEP_TIME = 200;       // retry sleep time in ms
+        internal const int MaxSendRetries = 3;
+        private const int RetrySleepTime = 200;       // retry sleep time in ms
 
         // URLs for requests
         private readonly string monitorURL;
@@ -94,24 +97,24 @@ namespace Dynatrace.OpenKit.Protocol
         // sends a status check request and returns a status response
         public StatusResponse SendStatusRequest()
         {
-            return (StatusResponse)SendRequest(RequestType.STATUS, monitorURL, null, null, "GET") ?? new StatusResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
+            return (StatusResponse)SendRequest(RequestType.Status, monitorURL, null, null, "GET") ?? new StatusResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
         }
 
         // sends a beacon send request and returns a status response
         public StatusResponse SendBeaconRequest(string clientIPAddress, byte[] data)
         {
-            return (StatusResponse)SendRequest(RequestType.BEACON, monitorURL, clientIPAddress, data, "POST") ?? new StatusResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
+            return (StatusResponse)SendRequest(RequestType.Beacon, monitorURL, clientIPAddress, data, "POST") ?? new StatusResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
         }
 
         // sends a time sync request and returns a time sync response
         public TimeSyncResponse SendTimeSyncRequest()
         {
-            return (TimeSyncResponse)SendRequest(RequestType.TIMESYNC, timeSyncURL, null, null, "GET") ?? new TimeSyncResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
+            return (TimeSyncResponse)SendRequest(RequestType.TimeSync, timeSyncURL, null, null, "GET") ?? new TimeSyncResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
         }
 
         public StatusResponse SendNewSessionRequest()
         {
-            return (StatusResponse)SendRequest(RequestType.NEW_SESSION, monitorURL, null, null, "GET") ?? new StatusResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
+            return (StatusResponse)SendRequest(RequestType.NewSession, monitorURL, null, null, "GET") ?? new StatusResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
         }
 
         // generic request send with some verbose output and exception handling
@@ -174,15 +177,15 @@ namespace Dynatrace.OpenKit.Protocol
                     }
 
                     // create typed response based on request type and response content
-                    if (requestType.RequestName == RequestType.TIMESYNC.RequestName)
+                    if (requestType.RequestName == RequestType.TimeSync.RequestName)
                     {
                         return httpResponse.Response == null || httpResponse.ResponseCode >= 400
                             ? new TimeSyncResponse(logger, string.Empty, httpResponse.ResponseCode, httpResponse.Headers)
                             : ParseTimeSyncResponse(httpResponse);
                     }
-                    else if ((requestType.RequestName == RequestType.BEACON.RequestName)
-                        || (requestType.RequestName == RequestType.STATUS.RequestName)
-                        || (requestType.RequestName == RequestType.NEW_SESSION.RequestName))
+                    else if ((requestType.RequestName == RequestType.Beacon.RequestName)
+                        || (requestType.RequestName == RequestType.Status.RequestName)
+                        || (requestType.RequestName == RequestType.NewSession.RequestName))
                     {
                         return httpResponse.Response == null || httpResponse.ResponseCode >= 400
                             ? new StatusResponse(logger, string.Empty, httpResponse.ResponseCode, httpResponse.Headers)
@@ -197,14 +200,14 @@ namespace Dynatrace.OpenKit.Protocol
                 catch (Exception exception)
                 {
                     retry++;
-                    if (retry > MAX_SEND_RETRIES)
+                    if (retry > MaxSendRetries)
                     {
                         throw exception;
                     }
 #if WINDOWS_UWP || NETPCL4_5
-                    System.Threading.Tasks.Task.Delay(RETRY_SLEEP_TIME).Wait();
+                    System.Threading.Tasks.Task.Delay(RetrySleepTime).Wait();
 #else
-                    Thread.Sleep(RETRY_SLEEP_TIME);
+                    Thread.Sleep(RetrySleepTime);
 #endif
                 }
             }
@@ -221,13 +224,13 @@ namespace Dynatrace.OpenKit.Protocol
                 catch (Exception e)
                 {
                     logger.Error(GetType().Name + " Failed to parse StatusResponse", e);
-                    return UnknownErrorResponse(RequestType.STATUS);
+                    return UnknownErrorResponse(RequestType.Status);
                 }
             }
 
             // invalid/unexpected response
             logger.Warn(GetType().Name + " The HTTPResponse \"" + httpResponse.Response + "\" is not a valid status response");
-            return UnknownErrorResponse(RequestType.STATUS);
+            return UnknownErrorResponse(RequestType.Status);
         }
 
         private Response ParseTimeSyncResponse(HTTPResponse httpResponse)
@@ -241,23 +244,23 @@ namespace Dynatrace.OpenKit.Protocol
                 catch(Exception e)
                 {
                     logger.Error(GetType().Name + " Failed to parse TimeSyncResponse", e);
-                    return UnknownErrorResponse(RequestType.TIMESYNC);
+                    return UnknownErrorResponse(RequestType.TimeSync);
                 }
             }
 
             // invalid/unexpected response
             logger.Warn(GetType().Name + " The HTTPResponse \"" + httpResponse.Response + "\" is not a valid time sync response");
-            return UnknownErrorResponse(RequestType.TIMESYNC);
+            return UnknownErrorResponse(RequestType.TimeSync);
         }
 
         private static bool IsStatusResponse(HTTPResponse httpResponse)
         {
-            return httpResponse.Response.StartsWith(REQUEST_TYPE_MOBILE);
+            return httpResponse.Response.StartsWith(RequestTypeMobile);
         }
 
         private static bool IsTimeSyncResponse(HTTPResponse httpResponse)
         {
-            return httpResponse.Response.StartsWith(REQUEST_TYPE_TIMESYNC);
+            return httpResponse.Response.StartsWith(RequestTypeTimeSync);
         }
 
         protected abstract HTTPResponse GetRequest(string url, string clientIPAddress);
@@ -271,13 +274,13 @@ namespace Dynatrace.OpenKit.Protocol
 
             monitorURLBuilder.Append(baseURL);
             monitorURLBuilder.Append('?');
-            monitorURLBuilder.Append(REQUEST_TYPE_MOBILE);
+            monitorURLBuilder.Append(RequestTypeMobile);
 
-            AppendQueryParam(monitorURLBuilder, QUERY_KEY_SERVER_ID, serverID.ToString());
-            AppendQueryParam(monitorURLBuilder, QUERY_KEY_APPLICATION, applicationID);
-            AppendQueryParam(monitorURLBuilder, QUERY_KEY_VERSION, ProtocolConstants.OPENKIT_VERSION);
-            AppendQueryParam(monitorURLBuilder, QUERY_KEY_PLATFORM_TYPE, Convert.ToString(ProtocolConstants.PLATFORM_TYPE_OPENKIT));
-            AppendQueryParam(monitorURLBuilder, QUERY_KEY_AGENT_TECHNOLOGY_TYPE, ProtocolConstants.AGENT_TECHNOLOGY_TYPE);
+            AppendQueryParam(monitorURLBuilder, QueryKeyServerId, serverID.ToString());
+            AppendQueryParam(monitorURLBuilder, QueryKeyApplication, applicationID);
+            AppendQueryParam(monitorURLBuilder, QueryKeyVersion, ProtocolConstants.OpenKitVersion);
+            AppendQueryParam(monitorURLBuilder, QueryKeyPlatformType, Convert.ToString(ProtocolConstants.PlatformTypeOpenKit));
+            AppendQueryParam(monitorURLBuilder, QueryKeyAgentTechnologyType, ProtocolConstants.AgentTechnologyType);
 
             return monitorURLBuilder.ToString();
         }
@@ -289,7 +292,7 @@ namespace Dynatrace.OpenKit.Protocol
 
             timeSyncURLBuilder.Append(baseURL);
             timeSyncURLBuilder.Append('?');
-            timeSyncURLBuilder.Append(REQUEST_TYPE_TIMESYNC);
+            timeSyncURLBuilder.Append(RequestTypeTimeSync);
 
             return timeSyncURLBuilder.ToString();
         }
@@ -300,7 +303,7 @@ namespace Dynatrace.OpenKit.Protocol
             urlBuilder.Append('&');
             urlBuilder.Append(key);
             urlBuilder.Append('=');
-            urlBuilder.Append(Uri.EscapeDataString(value));
+            urlBuilder.Append(PercentEncoder.Encode(value, Encoding.UTF8, QueryReservedCharacters));
         }
 
         private byte[] CompressByteArray(byte[] raw)
@@ -322,13 +325,13 @@ namespace Dynatrace.OpenKit.Protocol
             {
                 return null;
             }
-            else if ((requestType.RequestName == RequestType.STATUS.RequestName)
-                || (requestType.RequestName == RequestType.BEACON.RequestName)
-                || (requestType.RequestName == RequestType.NEW_SESSION.RequestName))
+            else if ((requestType.RequestName == RequestType.Status.RequestName)
+                || (requestType.RequestName == RequestType.Beacon.RequestName)
+                || (requestType.RequestName == RequestType.NewSession.RequestName))
             {
                 return new StatusResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
             }
-            else if ((requestType.RequestName == RequestType.TIMESYNC.RequestName))
+            else if ((requestType.RequestName == RequestType.TimeSync.RequestName))
             {
                 return new TimeSyncResponse(logger, string.Empty, int.MaxValue, new Dictionary<string, List<string>>());
             }

--- a/src/openkit-shared/Protocol/ProtocolConstants.cs
+++ b/src/openkit-shared/Protocol/ProtocolConstants.cs
@@ -19,12 +19,9 @@ namespace Dynatrace.OpenKit.Protocol
     public class ProtocolConstants
     {     
         // version constants
-        public const string OPENKIT_VERSION = "7.0.0000";
-        public const int PROTOCOL_VERSION = 3;
-        public const int PLATFORM_TYPE_OPENKIT = 1;
-        public const string AGENT_TECHNOLOGY_TYPE = "okdotnet";
+        public const string OpenKitVersion = "7.0.0000";
+        public const int ProtocolVersion = 3;
+        public const int PlatformTypeOpenKit = 1;
+        public const string AgentTechnologyType = "okdotnet";
     }
-
-
-
 }

--- a/src/openkit-shared/Util/IEnumerableExtensions.cs
+++ b/src/openkit-shared/Util/IEnumerableExtensions.cs
@@ -20,9 +20,7 @@ using System.Text;
 
 namespace Dynatrace.OpenKit.Util
 {
-
-#if NETPCL4_5
-
+    
     /// <summary>
     /// Utility class providing some extension methods which are not available in certain .NET flavors.
     /// </summary>
@@ -36,6 +34,4 @@ namespace Dynatrace.OpenKit.Util
             }
         }
     }
-
-#endif
 }

--- a/src/openkit-shared/openkit-shared.projitems
+++ b/src/openkit-shared/openkit-shared.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\Communication\SessionWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Configuration\BeaconCacheConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Configuration\BeaconConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Util\PercentEncoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CrashReportingLevel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataCollectionLevel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\DefaultLogger.cs" />

--- a/tests/openkit-shared-tests/Core/Configuration/OpenKitConfigurationTest.cs
+++ b/tests/openkit-shared-tests/Core/Configuration/OpenKitConfigurationTest.cs
@@ -186,7 +186,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
         }
 
         [Test]
-        public void GetApplicationIDPercentEncodedDoesPropperEncoding()
+        public void GetApplicationIDPercentEncodedDoesProperEncoding()
         {
             // given
             var target = CreateDefaultConfig();

--- a/tests/openkit-shared-tests/Core/Configuration/OpenKitConfigurationTest.cs
+++ b/tests/openkit-shared-tests/Core/Configuration/OpenKitConfigurationTest.cs
@@ -139,6 +139,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
         [Test]
         public void ADefaultConstructedConfigurationDisablesDataCollection()
         {
+            // given
             var target = CreateDefaultConfig();
 
             //when retrieving data collection level
@@ -151,6 +152,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
         [Test]
         public void ADefaultConstructedConfigurationDisablesCrashReporting()
         {
+            // given
             var target = CreateDefaultConfig();
 
             //when retrieving data collection level
@@ -163,6 +165,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
         [Test]
         public void ADefaultConstructedConfigurationUsesStrictTrustManager()
         {
+            // given
             var target = CreateDefaultConfig();
 
             //when retrieving SSL Trust manager
@@ -172,6 +175,25 @@ namespace Dynatrace.OpenKit.Core.Configuration
             Assert.That(sslTrustManager, Is.InstanceOf<SSLStrictTrustManager>());
         }
 
+        [Test]
+        public void GetApplicationID()
+        {
+            // given
+            var target = CreateDefaultConfig();
+
+            // then
+            Assert.That(target.ApplicationID, Is.EqualTo("/App_ID%"));
+        }
+
+        [Test]
+        public void GetApplicationIDPercentEncodedDoesPropperEncoding()
+        {
+            // given
+            var target = CreateDefaultConfig();
+
+            // then
+            Assert.That(target.ApplicationIDPercentEncoded, Is.EqualTo("%2FApp%5FID%25"));
+        }
 
         private static OpenKitConfiguration CreateDefaultConfig()
         {
@@ -182,7 +204,7 @@ namespace Dynatrace.OpenKit.Core.Configuration
 
             var defaultBeaconConfig = new BeaconConfiguration();
 
-            return new OpenKitConfiguration(OpenKitType.DYNATRACE, "", "", "0", "", new Providers.TestSessionIDProvider(),
+            return new OpenKitConfiguration(OpenKitType.DYNATRACE, "", "/App_ID%", "0", "", new Providers.TestSessionIDProvider(),
                   new SSLStrictTrustManager(), new Core.Device("", "", ""), "", defaultCacheConfig, defaultBeaconConfig);
         }
     }

--- a/tests/openkit-shared-tests/Core/Util/PercentEncoderTest.cs
+++ b/tests/openkit-shared-tests/Core/Util/PercentEncoderTest.cs
@@ -1,0 +1,105 @@
+﻿//
+// Copyright 2018 Dynatrace LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using NUnit.Framework;
+using System.Text;
+
+namespace Dynatrace.OpenKit.Core.Util
+{
+    [TestFixture]
+    class PercentEncoderTest
+    {
+        /// <summary>
+        /// All unreserved characters based on RFC-3986
+        /// </summary>
+        private const string UnreservedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+        
+        [Test]
+        public void RFC3986UnreservedCharactersAreNotEncoded()
+        {
+            // when
+            var obtained = PercentEncoder.Encode(UnreservedCharacters, Encoding.UTF8);
+
+            // then
+            Assert.That(obtained, Is.EqualTo(UnreservedCharacters));
+        }
+
+        [Test]
+        public void ReservedCharactersArePercentEncoded()
+        {
+            // when
+            var obtained = PercentEncoder.Encode("+()/\\&%$#@!`?<>[]{}", Encoding.UTF8);
+
+            // then
+            var expected = "%2B%28%29%2F%5C%26%25%24%23%40%21%60%3F%3C%3E%5B%5D%7B%7D"; // precomputed using Python
+            Assert.That(obtained, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MixingReservedAndUnreservedCharactersWorks()
+        {
+            // when
+            var obtained = PercentEncoder.Encode("a+bc()~/\\&0_", Encoding.UTF8);
+
+            // then
+            var expected = "a%2Bbc%28%29~%2F%5C%260_"; // precomputed using Python
+            Assert.That(obtained, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void CharactersOutsideOfAsciiRangeAreEncodedFirst()
+        {
+            // when
+            var obtained = PercentEncoder.Encode("aösÖ€dÁF", Encoding.UTF8);
+
+            // then
+            var expected = "a%C3%B6s%C3%96%E2%82%ACd%C3%81F";
+            Assert.That(obtained, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ItIsPossibleToMarkAdditionalCharactersAsReserved()
+        {
+            // when
+            var additionalReservedCharacters = new char[] { '€', '0', '_' };
+            var obtained = PercentEncoder.Encode("0123456789-._~", Encoding.UTF8, additionalReservedCharacters);
+
+            // then
+            var expected = "%30123456789-.%5F~";
+            Assert.That(obtained, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void NullIsReturnedIfNullIsPassedIn()
+        {
+            // when
+            var obtained = PercentEncoder.Encode(null, Encoding.ASCII);
+
+            // then
+            Assert.That(obtained, Is.Null);
+        }
+
+        [Test]
+        public void EmptyStringIsHandledSeparately()
+        {
+            // when
+            var obtained = PercentEncoder.Encode(string.Empty, Encoding.ASCII);
+
+            // then
+            Assert.That(obtained, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/tests/openkit-shared-tests/Protocol/BeaconTest.cs
+++ b/tests/openkit-shared-tests/Protocol/BeaconTest.cs
@@ -566,6 +566,24 @@ namespace Dynatrace.OpenKit.Protocol
         }
 
         [Test]
+        public void CreateWebRequestTagEncodesDeviceIDPropperly()
+        {
+            // given
+            var sessionIDProvider = Substitute.For<ISessionIDProvider>();
+            sessionIDProvider.GetNextSessionID().Returns(666);
+            var beaconConfig = new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OPT_IN_CRASHES);
+            var config = new TestConfiguration("app_ID", "device_id/", beaconConfig, sessionIDProvider);
+            var target = new Beacon(logger, new BeaconCache(logger), config, "127.0.0.1", threadIDProvider, timingProvider, randomGenerator);
+
+            //when
+            var obtained = target.CreateTag(42, 1);
+
+            // then
+            var expectedDeviceID = "MT_3_-1_device%5Fid%2F_666_app%5FID_42_0_1";
+            Assert.That(obtained, Is.EqualTo(expectedDeviceID));
+        }
+
+        [Test]
         public void DeviceIDIsRandomizedOnDataCollectionLevel0()
         {
             // given

--- a/tests/openkit-shared-tests/Protocol/HTTPClientTest.cs
+++ b/tests/openkit-shared-tests/Protocol/HTTPClientTest.cs
@@ -37,25 +37,25 @@ namespace Dynatrace.OpenKit.Protocol
         private const string ApplicationID = "ApplicationID";
 
         private static readonly string MonitorURL = BaseURL
-            + "?" + HTTPClient.REQUEST_TYPE_MOBILE
-            + "&" + HTTPClient.QUERY_KEY_SERVER_ID + "=" + ServerID
-            + "&" + HTTPClient.QUERY_KEY_APPLICATION + "=" + ApplicationID
-            + "&" + HTTPClient.QUERY_KEY_VERSION + "=" + ProtocolConstants.OPENKIT_VERSION
-            + "&" + HTTPClient.QUERY_KEY_PLATFORM_TYPE + "=" + ProtocolConstants.PLATFORM_TYPE_OPENKIT
-            + "&" + HTTPClient.QUERY_KEY_AGENT_TECHNOLOGY_TYPE + "=" + ProtocolConstants.AGENT_TECHNOLOGY_TYPE;
-        private const string TimeSyncURL = BaseURL + "?" + HTTPClient.REQUEST_TYPE_TIMESYNC;
+            + "?" + HTTPClient.RequestTypeMobile
+            + "&" + HTTPClient.QueryKeyServerId + "=" + ServerID
+            + "&" + HTTPClient.QueryKeyApplication + "=" + ApplicationID
+            + "&" + HTTPClient.QueryKeyVersion + "=" + ProtocolConstants.OpenKitVersion
+            + "&" + HTTPClient.QueryKeyPlatformType + "=" + ProtocolConstants.PlatformTypeOpenKit
+            + "&" + HTTPClient.QueryKeyAgentTechnologyType + "=" + ProtocolConstants.AgentTechnologyType;
+        private const string TimeSyncURL = BaseURL + "?" + HTTPClient.RequestTypeTimeSync;
 
         private static readonly HTTPClient.HTTPResponse StatusResponse = new HTTPClient.HTTPResponse
         {
             ResponseCode = 200,
-            Response = HTTPClient.REQUEST_TYPE_MOBILE,
+            Response = HTTPClient.RequestTypeMobile,
             Headers = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>>()
         };
 
         private static readonly HTTPClient.HTTPResponse TimeSyncResponse = new HTTPClient.HTTPResponse
         {
             ResponseCode = 200,
-            Response = HTTPClient.REQUEST_TYPE_TIMESYNC,
+            Response = HTTPClient.RequestTypeTimeSync,
             Headers = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>>()
         };
 

--- a/tests/openkit-shared-tests/TestConfiguration.cs
+++ b/tests/openkit-shared-tests/TestConfiguration.cs
@@ -34,13 +34,18 @@ namespace Dynatrace.OpenKit
         }
 
         internal TestConfiguration(string deviceID, BeaconConfiguration beaconConfig, ISessionIDProvider sessionIDProvider)
-            : base(OpenKitType.DYNATRACE, "", "", deviceID, "", sessionIDProvider, 
-                  new SSLStrictTrustManager(), new Core.Device("", "", ""), "", 
-                  new BeaconCacheConfiguration(
-                    BeaconCacheConfiguration.DEFAULT_MAX_RECORD_AGE_IN_MILLIS,
-                    BeaconCacheConfiguration.DEFAULT_LOWER_MEMORY_BOUNDARY_IN_BYTES,
-                    BeaconCacheConfiguration.DEFAULT_UPPER_MEMORY_BOUNDARY_IN_BYTES),
-                  beaconConfig)
+            : this("", deviceID, beaconConfig, sessionIDProvider)
+        {
+        }
+
+        internal TestConfiguration(string appID, string deviceID, BeaconConfiguration beaconConfig, ISessionIDProvider sessionIDProvider)
+            : base(OpenKitType.DYNATRACE, "", appID, deviceID, "", sessionIDProvider,
+          new SSLStrictTrustManager(), new Core.Device("", "", ""), "",
+          new BeaconCacheConfiguration(
+            BeaconCacheConfiguration.DEFAULT_MAX_RECORD_AGE_IN_MILLIS,
+            BeaconCacheConfiguration.DEFAULT_LOWER_MEMORY_BOUNDARY_IN_BYTES,
+            BeaconCacheConfiguration.DEFAULT_UPPER_MEMORY_BOUNDARY_IN_BYTES),
+          beaconConfig)
         {
             EnableCapture();
         }

--- a/tests/openkit-shared-tests/openkit-shared-tests.projitems
+++ b/tests/openkit-shared-tests/openkit-shared-tests.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\Configuration\OpenKitConfigurationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\RootActionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\SessionTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Util\PercentEncoderTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\WebRequestTracerBaseTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\WebRequestTracerStringURLTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OpenKitBuilderTest.cs" />


### PR DESCRIPTION
In addition, sometimes the underscore character _
is reserved in Dynatrace/AppMon, therefore we
need to URL-encode this character as well.